### PR TITLE
Fix for download link tests from passing when it shouldn't have been

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -145,7 +145,7 @@ class Base(Page):
         _privacy_locator = (By.CSS_SELECTOR, '.download-other > a:nth-of-type(3)')
 
         @property
-        def are_download_links_present(self):
+        def is_download_link_visible(self):
             return self.is_element_visible(*self._osx_download_locator) or \
             self.is_element_visible(*self._windows_download_locator) or \
             self.is_element_visible(*self._linux_download_locator)

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -33,7 +33,7 @@ class TestPerformance:
     def test_download_button_section(self, mozwebqa):
         performance_page = Performance(mozwebqa)
         performance_page.go_to_page()
-        Assert.true(performance_page.downloadRegion.are_download_links_present)
+        Assert.true(performance_page.downloadRegion.is_download_link_visible)
         Assert.true(performance_page.downloadRegion.are_secondary_links_visible)
 
     @pytest.mark.nondestructive

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -34,7 +34,7 @@ class TestSecurity:
     def test_download_button_section(self, mozwebqa):
         security_page = Security(mozwebqa)
         security_page.go_to_page()
-        Assert.true(security_page.downloadRegion.are_download_links_present)
+        Assert.true(security_page.downloadRegion.is_download_link_visible)
         Assert.true(security_page.downloadRegion.are_secondary_links_visible)
 
     @pytest.mark.nondestructive

--- a/tests/test_technology.py
+++ b/tests/test_technology.py
@@ -46,5 +46,5 @@ class TestTechnologyPage:
     def test_download_button_section(self, mozwebqa):
         technology_page = Technology(mozwebqa)
         technology_page.go_to_page()
-        Assert.true(technology_page.downloadRegion.are_download_links_present)
+        Assert.true(technology_page.downloadRegion.is_download_link_visible)
         Assert.true(technology_page.downloadRegion.are_secondary_links_visible)


### PR DESCRIPTION
So I think I figured out the issue that we were talking about in chat earlier. 

First, a definite issue was the CSS selectors for the Windows and Linux links were missing periods, which designates that as a class. Without the period, it couldn't find the links on the page and it would cause the test to fail after I made the change as described below.

The other issue was that the tests were passing when we weren't expecting them to. This might not be an issue, depending on what is the intention of download link test. If we want to check to see if the download link is **visible** for the respective OS the test is running from, than this commit should fix that. The test was passing with the invalid Windows/Linux CSS selectors because the OS X link was always **present** on the page and since it was returning all three values with an OR operator, it would always return true.

If the intention of the test is to check if these links are present, you would just need to change the operator on the function to AND.
