### PR TITLE
Changes to the way the footer is tested

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -82,47 +82,27 @@ class Base(Page):
 
     class Footer(Page):
 
-        _footer_locator = (By.CSS_SELECTOR, '#colophon')
+        _footer_link_locator_expression = '#colophon a[href$="%s"]'
         _footer_logo_link_locator = (By.CSS_SELECTOR, '.footer-logo > a')
         _footer_logo_img_locator = (By.CSS_SELECTOR, '.footer-logo img')
         expected_footer_logo_destination = '/en-US/'
         expected_footer_logo_img = '/media/img/sandstone/footer-mozilla.png'
 
         footer_links_list = [
-            {
-                'text': 'Creative Commons license',
-                'href': '/foundation/licensing/website-content.html',
-            },{
-                'text': 'Contact Us',
-                'href': '/en-US/about/contact.html#map-mountain_view',
-            },{
-                'text': 'Privacy Policy',
-                'href': '/en-US/privacy-policy.html',
-            },{
-                'text': 'Legal Notices',
-                'href': '/en-US/about/legal.html',
-            },{
-                'text': 'Report Trademark Abuse',
-                'href': '/en-US/legal/fraud-report/index.html',
-            },{
-                'text': 'Twitter',
-                'href': 'twitter.com/firefox',
-            },{
-                'text': 'Facebook',
-                'href': 'facebook.com/Firefox',
-            },{
-                'text': 'Firefox Affiliates',
-                'href': 'affiliates.mozilla.org',
-            },
+             '/foundation/licensing/website-content.html',
+             '/about/contact.html#map-mountain_view',
+             '/privacy-policy.html',
+             '/about/legal.html',
+             '/legal/fraud-report/index.html',
+             'twitter.com/firefox',
+             'facebook.com/Firefox',
+             'affiliates.mozilla.org/'
         ]
 
-        def footer_link_destination(self, footer_link_text):
-            footer_link = self.selenium.find_element(*self._footer_locator).find_element(
-                By.LINK_TEXT, footer_link_text)
-            return footer_link.get_attribute('href')
-
-        def footer_link_functions(self, footer_link_href):
-            return self.get_response_code(footer_link_href)
+        def footer_link_href(self, url_suffix):
+            return self.selenium.find_element(
+                By.CSS_SELECTOR,  self._footer_link_locator_expression % url_suffix
+            ).get_attribute('href')
 
         @property
         def footer_logo_destination(self):

--- a/pages/page.py
+++ b/pages/page.py
@@ -106,4 +106,9 @@ class Page(object):
         except urllib2.HTTPError, e:
             return e.code
 
+    def is_valid_link(self, url):
+        if self.get_response_code(url) == 200:
+            return True
+        return False
+
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from unittestzero import Assert
+
+
+class BaseTest:
+    """A base test class that can be extended by other tests to include utility methods."""
+
+    def verify_footer_section(self, page_object):
+        """Do the verification tasks that are common to all pages."""
+        Assert.contains(page_object.footer.expected_footer_logo_destination,
+            page_object.footer.footer_logo_destination)
+        Assert.contains(page_object.footer.expected_footer_logo_img,
+            page_object.footer.footer_logo_img)
+        for link in page_object.Footer.footer_links_list:
+            url = page_object.footer.footer_link_href(link)
+            Assert.true(page_object.is_valid_link(url))
+

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -6,25 +6,18 @@
 
 import pytest
 from unittestzero import Assert
+
 from pages.desktop.about import AboutPage
+from tests.base_test import BaseTest
 
 
-class TestAboutPage:
+class TestAboutPage(BaseTest):
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=773787")
     def test_footer_section(self, mozwebqa):
         about_page = AboutPage(mozwebqa)
         about_page.go_to_page()
-        for link in AboutPage.Footer.footer_links_list:
-            url = about_page.footer.footer_link_destination(link.get('text'))
-            Assert.contains(link.get('href'), url)
-            # the next line only exists for this page, to be a representative sample
-            Assert.equal(about_page.get_response_code(url), 200)
-        Assert.contains(about_page.footer.expected_footer_logo_img,
-            about_page.footer.footer_logo_img)
-        Assert.contains(about_page.footer.expected_footer_logo_destination,
-            about_page.footer.footer_logo_destination)
+        self.verify_footer_section(about_page)
 
     @pytest.mark.nondestructive
     def test_header_section(self, mozwebqa):

--- a/tests/test_b2g.py
+++ b/tests/test_b2g.py
@@ -5,22 +5,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from pages.desktop.b2g import BootToGecko
 from unittestzero import Assert
 
+from pages.desktop.b2g import BootToGecko
+from tests.base_test import BaseTest
 
-class TestBootToGecko:
+
+class TestBootToGecko(BaseTest):
 
     @pytest.mark.nondestructive
     def test_footer_section(self, mozwebqa):
         b2g_page = BootToGecko(mozwebqa)
         b2g_page.go_to_page()
-        Assert.contains(b2g_page.footer.expected_footer_logo_destination,
-            b2g_page.footer.footer_logo_destination)
-        Assert.contains(b2g_page.footer.expected_footer_logo_img,
-            b2g_page.footer.footer_logo_img)
-        for link in BootToGecko.Footer.footer_links_list:
-            Assert.contains(link.get('href'), b2g_page.footer.footer_link_destination(link.get('text')))
+        self.verify_footer_section(b2g_page)
 
     @pytest.mark.nondestructive
     def test_header_section(self, mozwebqa):

--- a/tests/test_contribute.py
+++ b/tests/test_contribute.py
@@ -5,23 +5,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from pages.desktop.contribute import Contribute
 from unittestzero import Assert
 
+from pages.desktop.contribute import Contribute
+from tests.base_test import BaseTest
 
-class TestContribute:
+
+class TestContribute(BaseTest):
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=773787")
     def test_footer_section(self, mozwebqa):
         contribute_page = Contribute(mozwebqa)
         contribute_page.go_to_page()
-        Assert.contains(contribute_page.footer.expected_footer_logo_destination,
-            contribute_page.footer.footer_logo_destination)
-        Assert.contains(contribute_page.footer.expected_footer_logo_img,
-            contribute_page.footer.footer_logo_img)
-        for link in Contribute.Footer.footer_links_list:
-            Assert.contains(link.get('href'), contribute_page.footer.footer_link_destination(link.get('text')))
+        self.verify_footer_section(contribute_page)
 
     @pytest.mark.nondestructive
     def test_header_section(self, mozwebqa):

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -4,11 +4,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from pages.desktop.mission import Mission
 from unittestzero import Assert
 
+from pages.desktop.mission import Mission
+from tests.base_test import BaseTest
 
-class TestMission:
+
+class TestMission(BaseTest):
 
     @pytest.mark.nondestructive
     def test_midpage_links(self, mozwebqa):
@@ -18,16 +20,10 @@ class TestMission:
         Assert.true(missionPage.is_video_visible)
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=773787")
     def test_footer_section(self, mozwebqa):
         mission_page = Mission(mozwebqa)
         mission_page.go_to_page()
-        Assert.contains(mission_page.footer.expected_footer_logo_destination,
-            mission_page.footer.footer_logo_destination)
-        Assert.contains(mission_page.footer.expected_footer_logo_img,
-            mission_page.footer.footer_logo_img)
-        for link in Mission.Footer.footer_links_list:
-            Assert.contains(link.get('href'), mission_page.footer.footer_link_destination(link.get('text')))
+        self.verify_footer_section(mission_page)
 
     @pytest.mark.nondestructive
     def test_header_section(self, mozwebqa):

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -5,23 +5,20 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from pages.desktop.partners import Partners
 from unittestzero import Assert
 
+from pages.desktop.partners import Partners
+from tests.base_test import BaseTest
 
-class TestPartners:
+
+class TestPartners(BaseTest):
 
     @pytest.mark.nondestructive
     @pytest.mark.bedrock
     def test_footer_section(self, mozwebqa):
         partners_page = Partners(mozwebqa)
         partners_page.go_to_page()
-        Assert.contains(partners_page.footer.expected_footer_logo_destination,
-            partners_page.footer.footer_logo_destination)
-        Assert.contains(partners_page.footer.expected_footer_logo_img,
-            partners_page.footer.footer_logo_img)
-        for link in Partners.Footer.footer_links_list:
-            Assert.contains(link.get('href'), partners_page.footer.footer_link_destination(link.get('text')))
+        self.verify_footer_section(partners_page)
 
     @pytest.mark.nondestructive
     def test_header_section(self, mozwebqa):

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -4,22 +4,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from unittestzero import Assert
-from pages.desktop.performance import Performance
 import pytest
 
+from pages.desktop.performance import Performance
+from tests.base_test import BaseTest
 
-class TestPerformance:
+
+class TestPerformance(BaseTest):
 
     @pytest.mark.nondestructive
     def test_footer_section(self, mozwebqa):
         performance_page = Performance(mozwebqa)
         performance_page.go_to_page()
-        Assert.contains(performance_page.footer.expected_footer_logo_destination,
-            performance_page.footer.footer_logo_destination)
-        Assert.contains(performance_page.footer.expected_footer_logo_img,
-            performance_page.footer.footer_logo_img)
-        for link in Performance.Footer.footer_links_list:
-            Assert.contains(link.get('href'), performance_page.footer.footer_link_destination(link.get('text')))
+        self.verify_footer_section(performance_page)
 
     @pytest.mark.nondestructive
     def test_header_section(self, mozwebqa):

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -6,17 +6,18 @@
 
 import pytest
 from unittestzero import Assert
+
 from pages.desktop.products import ProductsPage
+from tests.base_test import BaseTest
 
 
-class TestProductsPage:
+class TestProductsPage(BaseTest):
 
     @pytest.mark.nondestructive
     def test_footer_section(self, mozwebqa):
         products_page = ProductsPage(mozwebqa)
         products_page.go_to_page()
-        for link in ProductsPage.Footer.footer_links_list:
-            Assert.contains(link.get('href'), products_page.footer.footer_link_destination(link.get('text')))
+        self.verify_footer_section(products_page)
 
     @pytest.mark.nondestructive
     def test_header_section(self, mozwebqa):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -5,22 +5,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from pages.desktop.security import Security
 from unittestzero import Assert
 
+from pages.desktop.security import Security
+from tests.base_test import BaseTest
 
-class TestSecurity:
+
+class TestSecurity(BaseTest):
 
     @pytest.mark.nondestructive
     def test_footer_section(self, mozwebqa):
         security_page = Security(mozwebqa)
         security_page.go_to_page()
-        Assert.contains(security_page.footer.expected_footer_logo_destination,
-            security_page.footer.footer_logo_destination)
-        Assert.contains(security_page.footer.expected_footer_logo_img,
-            security_page.footer.footer_logo_img)
-        for link in Security.Footer.footer_links_list:
-            Assert.contains(link.get('href'), security_page.footer.footer_link_destination(link.get('text')))
+        self.verify_footer_section(security_page)
 
     @pytest.mark.nondestructive
     def test_header_section(self, mozwebqa):

--- a/tests/test_technology.py
+++ b/tests/test_technology.py
@@ -8,9 +8,10 @@ import pytest
 from unittestzero import Assert
 
 from pages.desktop.technology import Technology
+from tests.base_test import BaseTest
 
 
-class TestTechnologyPage:
+class TestTechnologyPage(BaseTest):
 
     @pytest.mark.nondestructive
     def test_billboard_links_are_visible(self, mozwebqa):
@@ -27,12 +28,7 @@ class TestTechnologyPage:
     def test_footer_section(self, mozwebqa):
         technology_page = Technology(mozwebqa)
         technology_page.go_to_page()
-        Assert.contains(technology_page.footer.expected_footer_logo_destination,
-            technology_page.footer.footer_logo_destination)
-        Assert.contains(technology_page.footer.expected_footer_logo_img,
-            technology_page.footer.footer_logo_img)
-        for link in Technology.Footer.footer_links_list:
-            Assert.contains(link.get('href'), technology_page.footer.footer_link_destination(link.get('text')))
+        self.verify_footer_section(technology_page)
 
     @pytest.mark.nondestructive
     def test_header_section(self, mozwebqa):


### PR DESCRIPTION
Note that this is a pretty big pull request, because once I changed the base object all the tests needed to be changed too. The changes are pretty much identical in each test file though.

I also introduced a base test object (which I had also done previously in marketplace-tests) because the code to test the footer is identical in each page's test, so there was a ton of duplication. 

Change summary:
Changed footer links to use css rather than link text
Added url response code verification
Removed an xfail for which the bug has been fixed
Created a BaseTest to include the code and asserts common to all tests
Updated each page's tests to use verify_footer_section from BaseTest
