### PR TITLE
fixing webmaker link until push to prod

### DIFF
--- a/pages/desktop/products.py
+++ b/pages/desktop/products.py
@@ -96,7 +96,7 @@ class ProductsPage(Base):
             'url_suffix': '/thunderbird/',
         }, {
             'locator': (By.CSS_SELECTOR, '#products li:nth-child(6) a'),
-            'url_suffix': '/webmaker/',
+            'url_suffix': 'webmaker.org/',
         }
     ]
 


### PR DESCRIPTION
fixing link for webmaker on products page. This should be merged when we push the changes from stage to production
