### PR TITLE
Fix baseurl for running selenium tests.

### DIFF
--- a/mozwebqa.cfg
+++ b/mozwebqa.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 api = webdriver
-baseurl = https://www-dev.allizom.org
+baseurl = https://www.allizom.org


### PR DESCRIPTION
Baseurl changed from https://www-dev.allizom.org to https://www.allizom.org
