### PR TITLE
Added a sample credentials file with a fake phone number for the send_sms test

### DIFF
--- a/credentials.yaml
+++ b/credentials.yaml
@@ -1,0 +1,2 @@
+default:
+  phone: 5555551212


### PR DESCRIPTION
There is currently no sample credentials file for this repo, and any phone number will work. Should I also submit a pull request to the private credentials repo to update the yaml file to be identical?
