### PR TITLE
Get response code timeout

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -102,7 +102,7 @@ class Page(object):
         # return the response status
         requests_config = {'max_retries': 5}
         try:
-            r = requests.head(url, verify=False, allow_redirects=True, config=requests_config, timeout=self.timeout)
+            r = requests.get(url, verify=False, allow_redirects=True, config=requests_config, timeout=self.timeout)
             return r.status_code
         except Timeout:
             return 408


### PR DESCRIPTION
I updated the `get_response_code` function so that it returns a timeout
http response. I noticed that http://getmockery.com/, one of the links
on the page, never loads and was causing the test to get stuck because
it can't handle a timeout.
