### PR TITLE
Fixing secondary links under download button

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -167,9 +167,9 @@ class Base(Page):
         _windows_download_locator = (By.CSS_SELECTOR, '.os_windows > a')
         _linux_download_locator = (By.CSS_SELECTOR, '.os_linux > a')
 
-        _systems_and_languages_locator = (By.CSS_SELECTOR, '.download-other > a:nth-of-type(1)')
-        _whats_new_locator = (By.CSS_SELECTOR, '.download-other > a:nth-of-type(2)')
-        _privacy_locator = (By.CSS_SELECTOR, '.download-other > a:nth-of-type(3)')
+        _systems_and_languages_locator = (By.CSS_SELECTOR, '.download-other.os_linux.os_osx.os_windows > a:nth-of-type(1)')
+        _whats_new_locator = (By.CSS_SELECTOR, '.download-other.os_linux.os_osx.os_windows > a:nth-of-type(2)')
+        _privacy_locator = (By.CSS_SELECTOR, '.download-other.os_linux.os_osx.os_windows > a:nth-of-type(3)')
 
         @property
         def is_download_link_visible(self):


### PR DESCRIPTION
Fixing secondary links under download button, the new button adds another locator .download-other for mobile which is hidden, therefore we need to specify full class selectors for desktop. This is on www-dev.allizom.org
