### PR TITLE
 Bug 840814  

### DIFF
--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -132,3 +132,15 @@ class TestRedirects(object):
         url = mozwebqa.base_url + "/firefox/all-older.html"
         response = requests.get(url)
         Assert.contains("/firefox/new", response.url)
+    
+    @pytest.mark.nondestructive
+    def test_old_firstrun_redirect(self, mozwebqa):
+        url = mozwebqa.base_url + "/en-US/projects/firefox/3.6.13/firstrun/"
+        response = requests.get(url)
+        Assert.not_equal(response.status_code, 404)
+    
+    @pytest.mark.nondestructive
+    def test_old_whatsnew_redirect(self, mozwebqa):
+        url = mozwebqa.base_url + '/en-US/projects/firefox/3.6.13/whatsnew/'
+        response = requests.get(url)
+        Assert.not_equal(response.status_code, 404)


### PR DESCRIPTION
old whatsnew and firstrun redirects with /projects/ in the middle should not 404
