### PR TITLE
Updating requests from 0.11.1 to 1.2.0

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -112,9 +112,10 @@ class Page(object):
 
     def get_response_code(self, url):
         # return the response status
-        requests_config = {'max_retries': 5}
+        #this sets max_retries to 5
+        requests.adapters.DEFAULT_RETRIES = 5
         try:
-            r = requests.get(url, verify=False, allow_redirects=True, config=requests_config, timeout=self.timeout)
+            r = requests.get(url, verify=False, allow_redirects=True, timeout=self.timeout)
             return r.status_code
         except Timeout:
             return 408

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ py==1.4.8
 pytest==2.2.4
 pytest-mozwebqa==1.0
 pytest-xdist==1.8
-requests==0.11.1
+requests==1.2.0
 selenium
 wsgiref==0.1.2


### PR DESCRIPTION
We are 22 versions behind on the  requests module.  The current version of the modules removes the config keyword argument which we use to set  the max_retries parameter.  We can set the max_retries  by setting the default retries to 5 in  requests.adapters .
requests.adapters.DEFAULT_RETRIES = 5
