### PR TITLE
Fix for failing test_partner_images_pager_one

### DIFF
--- a/pages/desktop/partners.py
+++ b/pages/desktop/partners.py
@@ -26,6 +26,7 @@ class Partners(Base):
     _android_menu_icon_locator = (By.CSS_SELECTOR, '#menu-android > a')
     _form_icon_locator = (By.CSS_SELECTOR, 'menu-form > a')
     _partner_pager_button_locator = (By.CSS_SELECTOR, '.pager-tabs > li:nth-of-type(2) > a')
+    _partner_page_one_button_locator = (By.CSS_SELECTOR, '.pager-tabs a[href="#mozilla-pager-page-1"]')
     partner_images_pager_list_one = [
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(1) > img'),
@@ -276,3 +277,6 @@ class Partners(Base):
     @property
     def is_phone_overlay_visible(self):
         return self.is_element_visible(*self._phone_image_locator)
+
+    def click_partner_page_one_button(self):
+        self.selenium.find_element(*self._partner_page_one_button_locator).click()

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -46,6 +46,7 @@ class TestPartners:
         partners_page.go_to_page()
         bad_images = []
         Assert.true(partners_page.is_partner_with_us_button_visible)
+        partners_page.click_partner_page_one_button()
         for image in partners_page.partner_images_pager_list_one:
             if not partners_page.is_element_visible(*image.get('locator')):
                 bad_images.append('The image at %s is not visible' % image.get('locator')[1:])


### PR DESCRIPTION
The test is failing in Jenkins. The locators for the images are ok, but the logo pages switch automatically before the test finishes checking the images. I added a click on the first page button to stop the automatic switch.
