### PR TITLE
Xfail due to Bug 882555 - /demos doesn't load -- redirects ad-naseum

### DIFF
--- a/tests/test_technology.py
+++ b/tests/test_technology.py
@@ -68,6 +68,7 @@ class TestTechnologyPage:
         Assert.equal(0, len(bad_links), '%s bad links found: ' % len(bad_links) + ', '.join(bad_links))
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail(reason="Bug 882555 - /demos doesn't load -- redirects ad-naseum")
     def test_more_info_link_urls_are_valid(self, mozwebqa):
         technology_page = Technology(mozwebqa)
         technology_page.go_to_page()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=882555
Here's the fail on prod: http://qa-selenium.mv.mozilla.com:8080/job/mozilla.com.prod/lastCompletedBuild/testReport/tests.test_technology/TestTechnologyPage/test_more_info_link_urls_are_valid/
