### PR TITLE
Fixing ESR redirects

### DIFF
--- a/tests/test_redirect_landing.py
+++ b/tests/test_redirect_landing.py
@@ -74,7 +74,7 @@ class TestRedirectLanding(object):
         headers = {}
         headers.update(self.ESR_FIREFOX)
         headers.update(self.ACCEPT_LANGUAGE)
-        self._test_redirect(mozwebqa, '/firefox/', '/firefox/new/', headers)
+        self._test_redirect(mozwebqa, '/firefox/', '/firefox/fx/', headers)
 
     @pytest.mark.nondestructive
     def test_redirect_esr_firefox_using_locale(self, mozwebqa):
@@ -82,7 +82,7 @@ class TestRedirectLanding(object):
         headers.update(self.ESR_FIREFOX)
         for locale in self.LOCALES:
             headers.update(self.ACCEPT_LANGUAGE)
-            self._test_redirect(mozwebqa, '/firefox/', '/firefox/new/', headers)
+            self._test_redirect(mozwebqa, '/firefox/', '/firefox/fx/', headers)
 
     @pytest.mark.nondestructive
     def test_redirect_ios_using_en_US(self, mozwebqa):


### PR DESCRIPTION
As per https://github.com/mozilla/bedrock/pull/1061, all ESR builds should be redirected to `/firefox/fx/` instead of `/firefox/new/`. This fixes https://github.com/mozilla/mcom-tests/pull/216.
