### PR TITLE
Remove tests for image source validity

### DIFF
--- a/tests/test_contribute.py
+++ b/tests/test_contribute.py
@@ -34,18 +34,6 @@ class TestContribute:
         Assert.equal(0, len(bad_images), '%s bad images found: ' % len(bad_images) + ', '.join(bad_images))
 
     @pytest.mark.nondestructive
-    def test_images_srcs_are_valid(self, mozwebqa):
-        contribute_page = Contribute(mozwebqa)
-        contribute_page.go_to_page()
-        bad_urls = []
-        for image in contribute_page.images_list:
-            url = contribute_page.image_source(image.get('locator'))
-            response_code = contribute_page.get_response_code(url)
-            if response_code != requests.codes.ok:
-                bad_urls.append('%s is not a valid url - status code: %s.' % (url, response_code))
-        Assert.equal(0, len(bad_urls), '%s bad urls found: ' % len(bad_urls) + ', '.join(bad_urls))
-
-    @pytest.mark.nondestructive
     def test_tools_links_are_visible(self, mozwebqa):
         contribute_page = Contribute(mozwebqa)
         contribute_page.go_to_page()

--- a/tests/test_partnerships.py
+++ b/tests/test_partnerships.py
@@ -66,18 +66,6 @@ class TestPartnerships:
         Assert.equal(0, len(bad_images), '%s bad images found: ' % len(bad_images) + ', '.join(bad_images))
 
     @pytest.mark.nondestructive
-    def test_image_srcs_are_valid(self, mozwebqa):
-        partnerships_page = Partnerships(mozwebqa)
-        partnerships_page.go_to_page()
-        bad_urls = []
-        for image in partnerships_page.images_list:
-            url = partnerships_page.image_source(image.get('locator'))
-            response_code = partnerships_page.get_response_code(url)
-            if response_code != requests.codes.ok:
-                bad_urls.append('%s is not a valid url - status code: %s.' % (url, response_code))
-        Assert.equal(0, len(bad_urls), '%s bad urls found: ' % len(bad_urls) + ', '.join(bad_urls))
-
-    @pytest.mark.nondestructive
     def test_partner_form_is_visible(self, mozwebqa):
         partnerships_page = Partnerships(mozwebqa)
         partnerships_page.go_to_page()

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -95,18 +95,6 @@ class TestProductsPage:
         Assert.equal(0, len(bad_images), '%s bad images found: ' % len(bad_images) + ', '.join(bad_images))
 
     @pytest.mark.nondestructive
-    def test_images_srcs_are_valid(self, mozwebqa):
-        products_page = ProductsPage(mozwebqa)
-        products_page.go_to_page()
-        bad_urls = []
-        for image in products_page.images_list:
-            url = products_page.image_source(image.get('locator'))
-            response_code = products_page.get_response_code(url)
-            if response_code != requests.codes.ok:
-                bad_urls.append('%s is not a valid url - status code: %s.' % (url, response_code))
-        Assert.equal(0, len(bad_urls), '%s bad urls found: ' % len(bad_urls) + ', '.join(bad_urls))
-
-    @pytest.mark.nondestructive
     def test_products_links_are_visible(self, mozwebqa):
         products_page = ProductsPage(mozwebqa)
         products_page.go_to_page()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -36,7 +36,7 @@ class TestSecurity:
         bad_links = []
         for link in Security.Header.tabzilla_links_list:
             url = security_page.link_destination(link.get('locator'))
-            if url.find(link.get('url_suffix'))  < 1:
+            if url.find(link.get('url_suffix')) < 1:
                 bad_links.append('%s does not end with %s' % (url, link.get('url_suffix')))
         Assert.equal(0, len(bad_links), '%s bad links found: ' % len(bad_links) + ', '.join(bad_links))
 
@@ -133,15 +133,3 @@ class TestSecurity:
             if not image.get('img_name_contains') in src:
                 bad_images.append('%s does not contain %s' % (src, image.get('img_name_contains')))
         Assert.equal(0, len(bad_images), '%s bad images found: ' % len(bad_images) + ', '.join(bad_images))
-
-    @pytest.mark.nondestructive
-    def test_images_srcs_are_valid(self, mozwebqa):
-        security_page = Security(mozwebqa)
-        security_page.go_to_page()
-        bad_urls = []
-        for image in security_page.images_list:
-            url = security_page.image_source(image.get('locator'))
-            response_code = security_page.get_response_code(url)
-            if response_code != requests.codes.ok:
-                bad_urls.append('%s is not a valid url - status code: %s.' % (url, response_code))
-        Assert.equal(0, len(bad_urls), '%s bad urls found: ' % len(bad_urls) + ', '.join(bad_urls))


### PR DESCRIPTION
Removing the tests for img src validity as the tests for visibility are already covering the test requirements.
