### PR TITLE
Changed manifesto link

### DIFF
--- a/pages/desktop/mission.py
+++ b/pages/desktop/mission.py
@@ -13,7 +13,7 @@ class Mission(Base):
     major_links_list = [
         {
             'locator': (By.CSS_SELECTOR, '#main-content div.main a'),
-            'url_suffix': '/about/manifesto.html',
+            'url_suffix': '/about/manifesto/',
         }, {
             'locator': (By.CSS_SELECTOR, '#main-content ul.links li:nth-child(1) a'),
             'url_suffix': '/contribute/',


### PR DESCRIPTION
This addresses <code>tests.test_mission.TestMission.test_major_link_destinations_are_correct</code> fail both on prod and stage 
http://qa-selenium.mv.mozilla.com:8080/view/Mozilla.com/job/mozilla.com.prod/lastCompletedBuild/testReport/tests.test_mission/TestMission/test_major_link_destinations_are_correct/
