### PR TITLE
Xfailed test_that_all_links_are_valid

### DIFF
--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -20,6 +20,8 @@ class TestNotes:
         notes_page.go_to_page()
         Assert.contains("Notes", notes_page.firefox_notes_header_text)
 
+    @pytest.mark.xfail("config.getvalue('base_url') == 'https://www.allizom.org'",
+                       reason="Bug 939707 - [stage] What's New link returns error 404")
     @pytest.mark.skip_selenium
     @pytest.mark.nondestructive
     def test_that_all_links_are_valid(self, mozwebqa):


### PR DESCRIPTION
http://qa-selenium.mv.mozilla.com:8080/view/Mozilla.com/job/mozilla.com.stage/lastCompletedBuild/testReport/tests.test_notes/TestNotes/test_that_all_links_are_valid/

Test Notes fails on stage because of bug https://bugzilla.mozilla.org/show_bug.cgi?id=939707

Release Notes page does not exist on STAGE (www.allizom.org/firefox/notes/) and test is verifying links on the wrong page
