### PR TITLE
Changed method for toggle_tabzilla_dropdown()

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -106,9 +106,9 @@ class Base(Page):
         ]
 
         def toggle_tabzilla_dropdown(self):
-            toggle_state = self.selenium.execute_script('Tabzilla.close()')
             self.selenium.find_element(*self._tabzilla).click()
-            WebDriverWait(self.selenium, 7).until(lambda state: toggle_state == state.execute_script('Tabzilla.open()'))
+            WebDriverWait(self.selenium, self.timeout).until(
+                lambda s: s.find_element(*self._tabzilla).get_attribute('class') == "tabzilla-opened")
 
         @property
         def is_tabzilla_panel_visible(self):


### PR DESCRIPTION
Changed this method because it was causing intermittent fails on prod
If script 'Tabzilla.close()' is run then sometimes if you clicked on the tabzilla it would not open:

http://screencast.com/t/xepsVMdM5sxC
