### PR TITLE
Remove xfail for test_that_notes_page_is_reachable

### DIFF
--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -12,8 +12,6 @@ from pages.desktop.notes import Notes
 
 class TestNotes:
 
-    @pytest.mark.xfail("config.getvalue('base_url') == 'https://www.allizom.org'",
-                       reason="Bug 939707 - [stage] What's New link returns error 404")
     @pytest.mark.nondestructive
     def test_that_notes_page_is_reachable(self, mozwebqa):
         notes_page = Notes(mozwebqa)


### PR DESCRIPTION
This test is now XPassed on CI
http://qa-selenium.mv.mozilla.com:8080/view/Mozilla.com/job/mozilla.com.stage/896/HTML_Report/?

Link that the test checks:
https://www.allizom.org/en-US/firefox/27.0/releasenotes/
