### PR TITLE
Fix partners images

### DIFF
--- a/pages/desktop/partners.py
+++ b/pages/desktop/partners.py
@@ -147,22 +147,6 @@ class Partners(Base):
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(12) > img'),
             'img_name_suffix': 'wikipedia.png'
-        },
-        {
-            'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(13) > img'),
-            'img_name_suffix': 'wired.png'
-        },
-        {
-            'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(14) > img'),
-            'img_name_suffix': 'terra.png'
-        },
-        {
-            'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(15) > img'),
-            'img_name_suffix': 'airbnb.png'
-        },
-        {
-            'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(16) > img'),
-            'img_name_suffix': 'disney.png'
         }
     ]
 


### PR DESCRIPTION
Four were removed from /firefox/partners/

This addresses the failures on CI such as [1].

[1] http://qa-selenium.mv.mozilla.com:8080/view/Mozilla.com/job/mozilla.com.prod/lastCompletedBuild/testReport/tests.test_partners/TestPartners/test_partner_images_pager_two/
