### PR TITLE
Bug 977355 - broken link to superheroes wanted on mozilla.org/contribute

### DIFF
--- a/pages/desktop/contribute.py
+++ b/pages/desktop/contribute.py
@@ -17,7 +17,7 @@ class Contribute(Base):
             'url_suffix': '//support.mozilla.org/get-involved',
         }, {
             'locator': (By.CSS_SELECTOR, 'li:nth-of-type(1) >.content > p > a:nth-of-type(2)'),
-            'url_suffix': '//support.mozillamessaging.com/kb/superheroes-wanted',
+            'url_suffix': '//support.mozilla.org/get-involved',
         }, {
             'locator': (By.CSS_SELECTOR, 'li:nth-of-type(2) >.content > p > a:nth-of-type(1)'),
             'url_suffix': '//quality.mozilla.org/teams/desktop-firefox/',


### PR DESCRIPTION
Update a Thunderbird KB link along with https://github.com/mozilla/bedrock/pull/1738.
