### PR TITLE
Bug 999152 - Add Firefox Cloud Services Privacy Notice to www.mozilla.org/privacy

### DIFF
--- a/pages/desktop/privacy.py
+++ b/pages/desktop/privacy.py
@@ -21,6 +21,12 @@ class Privacy(Base):
             'locator': (By.CSS_SELECTOR, '.policy-firefox'),
             'url_suffix': '/privacy/firefox/',
         }, {
+            'locator': (By.CSS_SELECTOR, '.policy-firefox-os'),
+            'url_suffix': '/privacy/firefox-os/',
+        }, {
+            'locator': (By.CSS_SELECTOR, '.policy-firefox-cloud'),
+            'url_suffix': '/privacy/firefox-cloud/',
+        }, {
             'locator': (By.CSS_SELECTOR, '.policy-marketplace'),
             'url_suffix': 'https://marketplace.firefox.com/privacy-policy',
         }, {


### PR DESCRIPTION
Update the tests once https://github.com/mozilla/bedrock/pull/1903 is deployed.
