### PR TITLE
Footer logo img locator no longer exists

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -119,10 +119,6 @@ class Base(Page):
 
         _footer_locator = (By.CSS_SELECTOR, '#colophon')
         _footer_logo_link_locator = (By.CSS_SELECTOR, 'h1.logo> a')
-        _footer_logo_img_locator = (By.CSS_SELECTOR, 'h1.logo> a >img')
-        expected_footer_logo_destination = '/en-US/'
-        expected_footer_logo_img = '/media/img/sandstone/footer-mozilla.png'
-
         footer_links_list = [
             {
                 'locator': (By.CSS_SELECTOR, '#colophon p.license a'),
@@ -175,13 +171,7 @@ class Base(Page):
             footer_logo_link = self.selenium.find_element(*self._footer_logo_link_locator)
             return footer_logo_link.get_attribute('href')
 
-        @property
-        def footer_logo_img(self):
-            footer_logo_img = self.selenium.find_element(*self._footer_logo_img_locator)
-            return footer_logo_img.get_attribute('src')
-
     class DownloadRegion(Page):
-
         _osx_download_locator = (By.CSS_SELECTOR, '.os_osx > a')
         _windows_download_locator = (By.CSS_SELECTOR, '.os_windows > a')
         _linux_download_locator = (By.CSS_SELECTOR, '.os_linux > a')

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -16,10 +16,6 @@ class TestAboutPage:
     def test_footer_link_destinations_are_correct(self, mozwebqa):
         about_page = AboutPage(mozwebqa)
         about_page.go_to_page()
-        Assert.contains(about_page.footer.expected_footer_logo_destination,
-                        about_page.footer.footer_logo_destination)
-        Assert.contains(about_page.footer.expected_footer_logo_img,
-                        about_page.footer.footer_logo_img)
         bad_links = []
         for link in AboutPage.Footer.footer_links_list:
             url = about_page.link_destination(link.get('locator'))
@@ -31,10 +27,6 @@ class TestAboutPage:
     def test_footer_links_are_valid(self, mozwebqa):
         about_page = AboutPage(mozwebqa)
         about_page.go_to_page()
-        Assert.contains(about_page.footer.expected_footer_logo_destination,
-                        about_page.footer.footer_logo_destination)
-        Assert.contains(about_page.footer.expected_footer_logo_img,
-                        about_page.footer.footer_logo_img)
         bad_urls = []
         for link in AboutPage.Footer.footer_links_list:
             url = about_page.link_destination(link.get('locator'))

--- a/tests/test_contribute.py
+++ b/tests/test_contribute.py
@@ -47,10 +47,6 @@ class TestContribute:
     def test_footer_section(self, mozwebqa):
         contribute_page = Contribute(mozwebqa)
         contribute_page.go_to_page()
-        Assert.contains(contribute_page.footer.expected_footer_logo_destination,
-                        contribute_page.footer.footer_logo_destination)
-        Assert.contains(contribute_page.footer.expected_footer_logo_img,
-                        contribute_page.footer.footer_logo_img)
         bad_links = []
         for link in Contribute.Footer.footer_links_list:
             url = contribute_page.link_destination(link.get('locator'))

--- a/tests/test_dnt.py
+++ b/tests/test_dnt.py
@@ -15,10 +15,6 @@ class TestDoNotTrack:
     def test_footer_section(self, mozwebqa):
         dnt_page = DoNotTrack(mozwebqa)
         dnt_page.go_to_page()
-        Assert.contains(dnt_page.footer.expected_footer_logo_destination,
-                        dnt_page.footer.footer_logo_destination)
-        Assert.contains(dnt_page.footer.expected_footer_logo_img,
-                        dnt_page.footer.footer_logo_img)
         bad_links = []
         for link in DoNotTrack.Footer.footer_links_list:
             url = dnt_page.link_destination(link.get('locator'))

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -60,10 +60,6 @@ class TestMission:
     def test_footer_section(self, mozwebqa):
         mission_page = Mission(mozwebqa)
         mission_page.go_to_page()
-        Assert.contains(mission_page.footer.expected_footer_logo_destination,
-                        mission_page.footer.footer_logo_destination)
-        Assert.contains(mission_page.footer.expected_footer_logo_img,
-                        mission_page.footer.footer_logo_img)
         bad_links = []
         for link in Mission.Footer.footer_links_list:
             url = mission_page.link_destination(link.get('locator'))

--- a/tests/test_mozillabased.py
+++ b/tests/test_mozillabased.py
@@ -29,10 +29,6 @@ class TestMozillaBasedPagePage:
     def test_footer_section_links(self, mozwebqa):
         page = MozillaBasedPage(mozwebqa)
         page.go_to_page()
-        Assert.contains(page.footer.expected_footer_logo_destination,
-                        page.footer.footer_logo_destination)
-        Assert.contains(page.footer.expected_footer_logo_img,
-                        page.footer.footer_logo_img)
         bad_links = []
         for link in MozillaBasedPage.Footer.footer_links_list:
             url = page.link_destination(link.get('locator'))

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -15,10 +15,6 @@ class TestPartners:
     def test_footer_section(self, mozwebqa):
         partners_page = Partners(mozwebqa)
         partners_page.go_to_page()
-        Assert.contains(partners_page.footer.expected_footer_logo_destination,
-                        partners_page.footer.footer_logo_destination)
-        Assert.contains(partners_page.footer.expected_footer_logo_img,
-                        partners_page.footer.footer_logo_img)
         bad_links = []
         for link in Partners.Footer.footer_links_list:
             url = partners_page.link_destination(link.get('locator'))

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -15,10 +15,6 @@ class TestPrivacy:
     def test_footer_section(self, mozwebqa):
         privacy_page = Privacy(mozwebqa)
         privacy_page.go_to_page()
-        Assert.contains(privacy_page.footer.expected_footer_logo_destination,
-                        privacy_page.footer.footer_logo_destination)
-        Assert.contains(privacy_page.footer.expected_footer_logo_img,
-                        privacy_page.footer.footer_logo_img)
         bad_links = []
         for link in Privacy.Footer.footer_links_list:
             url = privacy_page.link_destination(link.get('locator'))

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -16,10 +16,6 @@ class TestProductsPage:
     def test_footer_section(self, mozwebqa):
         products_page = ProductsPage(mozwebqa)
         products_page.go_to_page()
-        Assert.contains(products_page.footer.expected_footer_logo_destination,
-                        products_page.footer.footer_logo_destination)
-        Assert.contains(products_page.footer.expected_footer_logo_img,
-                        products_page.footer.footer_logo_img)
         bad_links = []
         for link in ProductsPage.Footer.footer_links_list:
             url = products_page.link_destination(link.get('locator'))

--- a/tests/test_sms.py
+++ b/tests/test_sms.py
@@ -57,10 +57,6 @@ class TestSMSPage():
     def test_footer_section(self, mozwebqa):
         sms_page = SMS(mozwebqa)
         sms_page.go_to_page()
-        Assert.contains(sms_page.footer.expected_footer_logo_destination,
-                        sms_page.footer.footer_logo_destination)
-        Assert.contains(sms_page.footer.expected_footer_logo_img,
-                        sms_page.footer.footer_logo_img)
         bad_links = []
         for link in sms_page.Footer.footer_links_list:
             url = sms_page.link_destination(link.get('locator'))


### PR DESCRIPTION
The footer logo used to be a an img under the .logo > a section.  The image has been moved to the background section of '#colophon .logo > a' 
