### PR TITLE
Fix os_section test.

### DIFF
--- a/pages/desktop/partners.py
+++ b/pages/desktop/partners.py
@@ -245,7 +245,7 @@ class Partners(Base):
 
     def click_os_menu(self):
         self.selenium.find_element(*self._os_menu_icon_locator).click()
-        WebDriverWait(self.selenium, self.timeout).until(EC.visibility_of_element_located(self._os_overview_button_locator))
+        WebDriverWait(self.selenium, self.timeout).until(EC.visibility_of_element_located(self._phone_os_image_locator))
 
     def click_operators_button(self):
         WebDriverWait(self.selenium, self.timeout).until(EC.element_to_be_clickable(self._operators_button_locator))


### PR DESCRIPTION
test_os_section is failing on Jenkins in the [mozilla.com.prod](http://selenium.qa.mtv2.mozilla.com:8080/view/All%20not%20B2G/job/mozilla.com.prod/1490/HTML_Report/) job because the site seems to move too fast and the test doesn't click on the operators link.
