### PR TITLE
Add new link to /contact/communities page

### DIFF
--- a/pages/desktop/contact.py
+++ b/pages/desktop/contact.py
@@ -288,6 +288,7 @@ class Communities(Contact):
         'contact/communities/kosovo/',
         'contact/communities/lithuania/',
         'contact/communities/macedonia/',
+        'contact/communities/montenegro/',
         'contact/communities/the-netherlands/',
         'contact/communities/norway/',
         'contact/communities/poland/',


### PR DESCRIPTION
The [mozilla.dev.com](http://selenium.qa.mtv2.mozilla.com:8080/job/mozilla.com.dev.saucelabs/762/HTML_Report/) jobs from Jenkins are failing because a new link has been added to the communities page. This PR should only be merged after the changes reach stage and prod.
ping @retornam
