### PR TITLE
Fixing DNT redirect and adding test for it

### DIFF
--- a/pages/desktop/dnt.py
+++ b/pages/desktop/dnt.py
@@ -11,7 +11,7 @@ from pages.desktop.base import Base
 class DoNotTrack(Base):
 
     def go_to_page(self):
-        self.open('/dnt')
+        self.open('/firefox/dnt')
 
     _dnt_status_wrapper_locator = (By.ID, 'dnt-status-wrapper')
     _dnt_status_text_locator = (By.CSS_SELECTOR, '#dnt-status > h4')

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -268,3 +268,11 @@ class TestRedirects(object):
         Assert.equal(response.status_code, 200)
         Assert.equal(response.history[0].status_code, 301)
         Assert.true(response.history[0].headers['location'].endswith('/en-US/privacy/archive/'))
+
+    @pytest.mark.nondestructive
+    def test_dnt_redirect(self, mozwebqa):
+        url = mozwebqa.base_url + '/dnt'
+        response = requests.get(url)
+        Assert.equal(response.status_code, 200)
+        Assert.equal(response.history[0].status_code, 301)
+        Assert.equal(response.history[-1].headers['location'].endswith('/firefox/dnt/'))


### PR DESCRIPTION
@stephendonner  r? This adds a redirect test and also updates the url in dnt.py to `/firefox/dnt` 
