### PR TITLE
Updated locator for sendto link and wordmark-white image

### DIFF
--- a/pages/desktop/home.py
+++ b/pages/desktop/home.py
@@ -27,7 +27,7 @@ class HomePage(Base):
             'url_suffix': '/firefox/desktop/',
         }, {
             'locator': (By.CSS_SELECTOR, '#promo-6 a'),
-            'url_suffix': '//sendto.mozilla.org/page/contribute/givenow-1page?preset=2&source=mozillaorg_largeblock&ref=EOYFR2014&utm_campaign=EOYFR2014&utm_source=mozilla.org&utm_medium=referral&utm_content=mozillaorg_largeblock',
+            'url_suffix': '//sendto.mozilla.org/page/contribute/givenow-seq?preset=2&source=mozillaorg_largeblock&ref=EOYFR2014&utm_campaign=EOYFR2014&utm_source=mozilla.org&utm_medium=referral&utm_content=mozillaorg_largeblock',
         }, {
             'locator': (By.CSS_SELECTOR, '#promo-8 a'),
             'url_suffix': '//webmaker.org/',


### PR DESCRIPTION
Fix for locators in failing tests [test home: major link & image srcs]
