### PR TITLE
Fix home-page promo link tests

### DIFF
--- a/pages/desktop/home.py
+++ b/pages/desktop/home.py
@@ -21,13 +21,13 @@ class HomePage(Base):
             'url_suffix': '/firefox/independent/#play',
         }, {
             'locator': (By.CSS_SELECTOR, '#promo-2 a'),
-            'url_suffix': '/privacy/you/',
+            'url_suffix': '//advocacy.mozilla.org/',
         }, {
             'locator': (By.CSS_SELECTOR, '#promo-5 .fxos-link'),
             'url_suffix': '/firefox/desktop/',
         }, {
             'locator': (By.CSS_SELECTOR, '#promo-6 a'),
-            'url_suffix': '//webmaker.org/',
+            'url_suffix': '/privacy/you/',
         }, {
             'locator': (By.CSS_SELECTOR, '#promo-8 a'),
             'url_suffix': '//webmaker.org/appmaker',


### PR DESCRIPTION
Fixes home page promo link tests that we're updated in [bedrock PR 2661](https://github.com/mozilla/bedrock/pull/2661)

@jgmize r?

On a side note, I do wonder whether it's a good thing to be testing the link destinations for home page promo's in general, given that they change so often. Also now that we're using waffle to flip promo's, it seems to make less sense. Thoughts?

This PR fixes the tests for now, but I wonder if we should really remove/update these tests. We could leave the major link tests that don't tend to change, and then just test that promo links actually have valid responses?

I'd be happy to try and work this out and submit a follow-up PR, if it makes sense to do so.
