### PR TITLE
Update homepage promo tests to check valid link responses only

### DIFF
--- a/pages/desktop/home.py
+++ b/pages/desktop/home.py
@@ -17,30 +17,6 @@ class HomePage(Base):
 
     major_links_list = [
         {
-            'locator': (By.CSS_SELECTOR, '#promo-1 a'),
-            'url_suffix': '/firefox/independent/#play',
-        }, {
-            'locator': (By.CSS_SELECTOR, '#promo-2 a'),
-            'url_suffix': '/privacy/you/',
-        }, {
-            'locator': (By.CSS_SELECTOR, '#promo-5 .fxos-link'),
-            'url_suffix': '/firefox/desktop/',
-        }, {
-            'locator': (By.CSS_SELECTOR, '#promo-6 a'),
-            'url_suffix': '//webmaker.org/',
-        }, {
-            'locator': (By.CSS_SELECTOR, '#promo-8 a'),
-            'url_suffix': '//webmaker.org/appmaker',
-        }, {
-            'locator': (By.CSS_SELECTOR, '#promo-10 a'),
-            'url_suffix': '/firefox/developer/',
-        }, {
-            'locator': (By.CSS_SELECTOR, '#promo-11 a'),
-            'url_suffix': '//gear.mozilla.org/?ref=OMG_launch&utm_campaign=OMG_launch&utm_source=gear.mozilla.org&utm_medium=referral&utm_content=mozillaorg_largeblock',
-        }, {
-            'locator': (By.CSS_SELECTOR, '#promo-16 .twt-actions a:nth-child(1)'),
-            'url_suffix': '//twitter.com/firefox',
-        }, {
             'locator': (By.CSS_SELECTOR, '#firefox-download-section header a'),
             'url_suffix': '/firefox/',
         }, {
@@ -59,6 +35,57 @@ class HomePage(Base):
             'locator': (By.CSS_SELECTOR, '#secondary-links li:nth-child(3) a'),
             'url_suffix': '//support.mozilla.org/',
         }
+    ]
+
+    promo_links_list = [
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-1 .panel-link')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-2 .panel-link')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-3 > a')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-4 > a')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-5 .fxos-link')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-6 .panel-link')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-7 > a')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-8 .panel-link')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-9 .panel-link')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-10 .panel-link')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-11 .panel-link')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-12 > a')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-13 > a')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-14 > a')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-15 > a')
+        },
+        {
+            'locator': (By.CSS_SELECTOR, '#promo-16 .twt-actions a:nth-child(1)')
+        },
     ]
 
     images_list = [

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -13,6 +13,18 @@ from pages.desktop.home import HomePage
 class TestHomePage:
 
     @pytest.mark.nondestructive
+    def test_promo_links_are_valid(self, mozwebqa):
+        home_page = HomePage(mozwebqa)
+        home_page.go_to_page()
+        bad_urls = []
+        for link in home_page.promo_links_list:
+            url = home_page.link_destination(link.get('locator'))
+            response_code = home_page.get_response_code(url)
+            if response_code != requests.codes.ok:
+                bad_urls.append('%s is not a valid url - status code: %s.' % (url, response_code))
+        Assert.equal(0, len(bad_urls), '%s bad urls found: ' % len(bad_urls) + ', '.join(bad_urls))
+
+    @pytest.mark.nondestructive
     def test_major_link_urls_are_valid(self, mozwebqa):
         home_page = HomePage(mozwebqa)
         home_page.go_to_page()


### PR DESCRIPTION
Updating home page promo tests to only check for valid link responses, as opposed to also each promo `href`. 

Because homepage promo's change quite often, these tests are probably a bit overly specific and require more maintenance than they should. We are also now using waffle on the home page to toggle different promo's, so checking each `href` specifically might not be appropriate any more.