### PR TITLE
Bug 906176: Fix tests for bedrock move to staticfiles.

### DIFF
--- a/pages/desktop/dnt.py
+++ b/pages/desktop/dnt.py
@@ -25,7 +25,7 @@ class DoNotTrack(Base):
         },
         {
             'locator': (By.CSS_SELECTOR, '.sidebar-box > p > a:nth-of-type(2)'),
-            'url_suffix': 'dnt-enabler.tpl'
+            'url_suffix': 'dnt-enabler.*.tpl'
         }
     ]
 

--- a/pages/desktop/home.py
+++ b/pages/desktop/home.py
@@ -91,10 +91,10 @@ class HomePage(Base):
     images_list = [
         {
             'locator': (By.CSS_SELECTOR, '.primary img'),
-            'img_name_suffix': 'firefox-logo.png',
+            'img_name_suffix': 'firefox-logo.*.png',
         }, {
             'locator': (By.CSS_SELECTOR, '#firefox-promo-link img'),
-            'img_name_suffix': 'firefox-logo-wordmark-white.png',
+            'img_name_suffix': 'firefox-logo-wordmark-white.*.png',
         }
     ]
 

--- a/pages/desktop/partners.py
+++ b/pages/desktop/partners.py
@@ -37,93 +37,93 @@ class Partners(Base):
     partner_images_pager_list_one = [
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(1) > img'),
-            'img_name_suffix': 'telefonica.png'
+            'img_name_suffix': 'telefonica.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(2) > img'),
-            'img_name_suffix': 'dt.png'
+            'img_name_suffix': 'dt.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(3) > img'),
-            'img_name_suffix': 'lg.png'
+            'img_name_suffix': 'lg.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(4) > img'),
-            'img_name_suffix': 'qualcomm.png'
+            'img_name_suffix': 'qualcomm.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(5) > img'),
-            'img_name_suffix': 'zte.png'
+            'img_name_suffix': 'zte.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(6) > img'),
-            'img_name_suffix': 'telenor.png'
+            'img_name_suffix': 'telenor.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(7) > img'),
-            'img_name_suffix': 'americamovil.png'
+            'img_name_suffix': 'americamovil.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(8) > img'),
-            'img_name_suffix': 'tcl.png'
+            'img_name_suffix': 'tcl.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(9) > img'),
-            'img_name_suffix': 'telecomitalia.png'
+            'img_name_suffix': 'telecomitalia.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(10) > img'),
-            'img_name_suffix': 'chinaunicom.png'
+            'img_name_suffix': 'chinaunicom.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(11) > img'),
-            'img_name_suffix': 'kddi.png'
+            'img_name_suffix': 'kddi.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(12) > img'),
-            'img_name_suffix': 'sprint.png'
+            'img_name_suffix': 'sprint.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(13) > img'),
-            'img_name_suffix': 'singtel.png'
+            'img_name_suffix': 'singtel.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(14) > img'),
-            'img_name_suffix': 'etisalat.png'
+            'img_name_suffix': 'etisalat.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(15) > img'),
-            'img_name_suffix': 'koreatelecom.png'
+            'img_name_suffix': 'koreatelecom.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-1 > .logos > li:nth-of-type(16) > img'),
-            'img_name_suffix': 'vimpelcom.png'
+            'img_name_suffix': 'vimpelcom.*.png'
         }
     ]
 
     partner_images_pager_list_two = [
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(2) > img'),
-            'img_name_suffix': 'portugaltelecom.png'
+            'img_name_suffix': 'portugaltelecom.*.png'
         }, {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(2) > img'),
-            'img_name_suffix': 'portugaltelecom.png'
+            'img_name_suffix': 'portugaltelecom.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(3) > img'),
-            'img_name_suffix': 'megafon.png'
+            'img_name_suffix': 'megafon.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(4) > img'),
-            'img_name_suffix': 'facebook.png'
+            'img_name_suffix': 'facebook.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(5) > img'),
-            'img_name_suffix': 'twitter.png'
+            'img_name_suffix': 'twitter.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(6) > img'),
-            'img_name_suffix': 'soundcloud.png'
+            'img_name_suffix': 'soundcloud.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(7) > img'),
@@ -131,23 +131,23 @@ class Partners(Base):
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(8) > img'),
-            'img_name_suffix': 'box.png'
+            'img_name_suffix': 'box.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(9) > img'),
-            'img_name_suffix': 'ea.png'
+            'img_name_suffix': 'ea.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(10) > img'),
-            'img_name_suffix': 'ebay.png'
+            'img_name_suffix': 'ebay.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(11) > img'),
-            'img_name_suffix': 'cuttherope.png'
+            'img_name_suffix': 'cuttherope.*.png'
         },
         {
             'locator': (By.CSS_SELECTOR, '#page-mozilla-pager-page-2 > .logos > li:nth-of-type(12) > img'),
-            'img_name_suffix': 'wikipedia.png'
+            'img_name_suffix': 'wikipedia.*.png'
         }
     ]
 

--- a/pages/desktop/products.py
+++ b/pages/desktop/products.py
@@ -29,40 +29,40 @@ class ProductsPage(Base):
     images_list = [
         {
             'locator': (By.CSS_SELECTOR, '#firefox li:nth-child(1) a img'),
-            'img_name_suffix': 'badge-firefox.jpg?2013-06',
+            'img_name_suffix': 'badge-firefox.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#firefox li:nth-child(2) a img'),
-            'img_name_suffix': 'badge-android.jpg',
+            'img_name_suffix': 'badge-android.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#firefox li:nth-child(3) a img'),
-            'img_name_suffix': 'badge-firefoxos.jpg?2013-06',
+            'img_name_suffix': 'badge-firefoxos.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#firefox li:nth-child(4) a img'),
-            'img_name_suffix': 'badge-marketplace.jpg?2013-06',
+            'img_name_suffix': 'badge-marketplace.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#mozilla li:nth-child(1) a img'),
-            'img_name_suffix': 'badge-persona.jpg',
+            'img_name_suffix': 'badge-persona.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#mozilla li:nth-child(2) a img'),
-            'img_name_suffix': 'badge-webmaker.jpg',
+            'img_name_suffix': 'badge-webmaker.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#mozilla li:nth-child(3) a img'),
-            'img_name_suffix': 'badge-thunderbird.jpg',
+            'img_name_suffix': 'badge-thunderbird.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#developers li:nth-child(1) a img'),
-            'img_name_suffix': 'badge-bugzilla.jpg',
+            'img_name_suffix': 'badge-bugzilla.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#developers li:nth-child(2) a img'),
-            'img_name_suffix': 'badge-firebug.jpg',
+            'img_name_suffix': 'badge-firebug.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#developers li:nth-child(3) a img'),
-            'img_name_suffix': 'badge-xulrunner.jpg',
+            'img_name_suffix': 'badge-xulrunner.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#developers li:nth-child(4) img'),
-            'img_name_suffix': 'badge-gecko.jpg',
+            'img_name_suffix': 'badge-gecko.*.jpg',
         }, {
             'locator': (By.CSS_SELECTOR, '#developers li:nth-child(5) img'),
-            'img_name_suffix': 'badge-api.jpg',
+            'img_name_suffix': 'badge-api.*.jpg',
         }
     ]
 

--- a/tests/test_dnt.py
+++ b/tests/test_dnt.py
@@ -3,6 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from fnmatch import fnmatchcase
 
 import pytest
 from pages.desktop.dnt import DoNotTrack
@@ -46,6 +47,6 @@ class TestDoNotTrack:
         bad_links = []
         for link in dnt_page.tracking_protection_links_list:
             url = dnt_page.link_destination(link.get('locator'))
-            if not url.endswith(link.get('url_suffix')):
-                bad_links.append('%s does not end with %s' % (url, link.get('url_suffix')))
+            if not fnmatchcase(url, '*/' + link.get('url_suffix')):
+                bad_links.append('%s does not match %s' % (url, link.get('url_suffix')))
         Assert.equal(0, len(bad_links), '%s bad links found: ' % len(bad_links) + ', '.join(bad_links))

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -3,6 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from fnmatch import fnmatchcase
 
 import pytest
 import requests
@@ -87,8 +88,8 @@ class TestHomePage:
         bad_images = []
         for image in home_page.images_list:
             src = home_page.image_source(image.get('locator'))
-            if not src.endswith(image.get('img_name_suffix')):
-                bad_images.append('%s does not end with %s' % (src, image.get('img_name_suffix')))
+            if not fnmatchcase(src, '*/' + image.get('img_name_suffix')):
+                bad_images.append('%s does not match %s' % (src, image.get('img_name_suffix')))
         Assert.equal(0, len(bad_images), '%s bad images found: ' % len(bad_images) + ', '.join(bad_images))
 
     @pytest.mark.nondestructive

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -3,6 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from fnmatch import fnmatchcase
 
 import pytest
 import requests
@@ -66,8 +67,8 @@ class TestProductsPage:
         bad_images = []
         for image in products_page.images_list:
             src = products_page.image_source(image.get('locator'))
-            if not src.endswith(image.get('img_name_suffix')):
-                bad_images.append('%s does not end with %s' % (src, image.get('img_name_suffix')))
+            if not fnmatchcase(src, '*/' + image.get('img_name_suffix')):
+                bad_images.append('%s does not match %s' % (src, image.get('img_name_suffix')))
         Assert.equal(0, len(bad_images), '%s bad images found: ' % len(bad_images) + ', '.join(bad_images))
 
     @pytest.mark.nondestructive


### PR DESCRIPTION
Also django-pipeline and Whitenoise. All static files
(css, js, images, fonts, etc.) will now be named with
the md5 hash of the file contents (e.g. old-logo.deadbeef123.png)
thus making it impossible for this suite to know the full file
name. This switches those tests to use fnmatch from the
Python stdlib.