### PR TITLE
add try/except block to catch requests exceptions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ py==1.4.15
 pytest==2.3.5
 pytest-mozwebqa
 pytest-xdist==1.8
-requests==2.4.3
+requests==2.6.0
 selenium
 wsgiref==0.1.2

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -46,10 +46,13 @@ class TestLocalizations:
             links = language.findAll('a')
             for link in links:
                 url = link['href']
-                response = requests.head(url, allow_redirects=False)
-                status = response.status_code
-                if not (300 < status <= 302):
-                    bad_links.append("Lang '%s' %s link: status %s"
-                                     % (language['id'], link['href'], status))
+                try:
+                    response = requests.head(url, allow_redirects=False)
+                    status = response.status_code
+                    if not (300 < status <= 302):
+                        bad_links.append("Lang '%s' %s link: status %s" %
+                                         (language['id'], link['href'], status))
+                except Exception, e:
+                    bad_links.append("Exception thrown: %s url: %s" % (e, url))
         Assert.equal(0, len(bad_links),
                      "Expected status code 302.  " + ",  ".join(bad_links))


### PR DESCRIPTION
We're seeing failures marked by this exception being thrown: `[Errno 8] _ssl.c:507: EOF occurred in violation of protocol`. 
* added a try/except block to better report failures in the future.
* bump `requests` version.