### PR TITLE
Revert "Upgrade py.test dependency to 2.7"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ certifi==0.0.8
 chardet==2.1.1
 execnet==1.1
 py==1.4.15
-pytest==2.7.0
+pytest==2.3.5
 pytest-mozwebqa
+pytest-xdist==1.8
 requests==2.6.0
 selenium
 wsgiref==0.1.2


### PR DESCRIPTION
Reverts mozilla/mcom-tests#406