### PR TITLE
Revert "Added 2 tests for the contributor signup page"

### DIFF
--- a/pages/desktop/contribute.py
+++ b/pages/desktop/contribute.py
@@ -4,11 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from random import randint
-
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.select import Select
-
 from pages.desktop.base import Base
 
 
@@ -72,38 +68,9 @@ class Signup(Contribute):
 
     _testing_area_locator = (By.CSS_SELECTOR, '.categories .option #category-testing')
     _sign_up_form_locator = (By.CSS_SELECTOR, '.personal')
-    _coding_topic_locator = (By.CSS_SELECTOR, 'label.category-coding')
-    _testing_topic_locator = (By.CSS_SELECTOR, 'label.category-testing')
-    _coding_subtopic_locator = (By.ID, 'id_area_coding')
-    _testing_subtopic_locator = (By.ID, 'id_area_testing')
-    _submit_button_locator = (By.CSS_SELECTOR, '.submit button')
 
     def click_testing_area(self):
         self.selenium.find_element(*self._testing_area_locator).click()
-
-    def click_coding_topic(self):
-        self.selenium.find_element(*self._coding_topic_locator).click()
-
-    def click_testing_topic(self):
-        self.selenium.find_element(*self._testing_topic_locator).click()
-
-    def select_random_coding_subtopic(self):
-        coding_subtopics = ['coding-firefox', 'coding-firefoxos',
-                            'coding-websites', 'coding-addons',
-                            'coding-marketplace', 'coding-webcompat',
-                            'coding-cloud']
-
-        element = self.selenium.find_element(*self._coding_subtopic_locator)
-        select = Select(element)
-        select.select_by_value(coding_subtopics[randint(0, 6)])
-
-    def select_random_testing_subtopic(self):
-        subtopics = ['testing-firefox', 'testing-addons', 'testing-marketplace',
-                     'testing-websites', 'testing-webcompat']
-
-        element = self.selenium.find_element(*self._testing_subtopic_locator)
-        select = Select(element)
-        select.select_by_value(subtopics[randint(0, 4)])
 
     sign_up_form_fields = [
         {
@@ -114,42 +81,12 @@ class Signup(Contribute):
         }, {
             'locator': (By.ID, 'id_country'),
         }, {
-            'locator': (By.CSS_SELECTOR, 'input[type="radio"][value="T"]'),
-        }, {
             'locator': (By.ID, 'id_privacy'),
+        }, {
+            'locator': (By.CSS_SELECTOR, 'button'),
         },
     ]
 
     @property
     def is_sign_up_form_present(self):
         return self.is_element_present(*self._sign_up_form_locator)
-
-    def complete_sign_up_form(self):
-        # Name
-        element = self.selenium.find_element(*self.sign_up_form_fields[0]['locator'])
-        element.send_keys('QA Test User')
-        # Email
-        element = self.selenium.find_element(*self.sign_up_form_fields[1]['locator'])
-        element.send_keys('f1258291@trbvm.com')
-        # Country
-        element = self.selenium.find_element(*self.sign_up_form_fields[2]['locator'])
-        select = Select(element)
-        select.select_by_value('us')
-        # Format
-        element = self.selenium.find_element(*self.sign_up_form_fields[3]['locator'])
-        element.click()
-        # Privacy
-        element = self.selenium.find_element(*self.sign_up_form_fields[4]['locator'])
-        element.click()
-
-    def click_submit_button(self):
-        self.selenium.find_element(*self._submit_button_locator).click()
-        return ConfirmationPage(self.testsetup)
-
-
-class ConfirmationPage(Contribute):
-
-    _confirmation_text_locator = (By.CSS_SELECTOR, '#thankyou .section-tagline')
-
-    def confirmation_text(self):
-        return (self.selenium.find_element(*self._confirmation_text_locator)).text

--- a/tests/test_contribute.py
+++ b/tests/test_contribute.py
@@ -6,11 +6,8 @@
 
 import pytest
 import requests
-
-from unittestzero import Assert
-
 from pages.desktop.contribute import Contribute, Signup
-
+from unittestzero import Assert
 
 
 class TestContribute:
@@ -78,27 +75,3 @@ class TestContribute:
         signup_page = Signup(mozwebqa)
         signup_page.go_to_page()
         Assert.true(signup_page.is_sign_up_form_present, 'The sign up form is not present on the page.')
-
-    def test_coding_signup_form(self, mozwebqa):
-        signup_page = Signup(mozwebqa)
-        signup_page.go_to_page()
-
-        signup_page.click_coding_topic()
-        signup_page.select_random_coding_subtopic()
-
-        signup_page.complete_sign_up_form()
-        confirmation_page = signup_page.click_submit_button()
-
-        Assert.true('coding' in confirmation_page.confirmation_text())
-
-    def test_testing_signup_form(self, mozwebqa):
-        signup_page = Signup(mozwebqa)
-        signup_page.go_to_page()
-
-        signup_page.click_testing_topic()
-        signup_page.select_random_testing_subtopic()
-
-        signup_page.complete_sign_up_form()
-        confirmation_page = signup_page.click_submit_button()
-
-        Assert.true('testing' in confirmation_page.confirmation_text())


### PR DESCRIPTION
Reverts mozilla/mcom-tests#388

I do not believe these tests actually pass in any environment. They fail in dev and demo due to an incorrect css selector, and are incorrectly reported as a "pass" in stage in prod despite not being run due to the lack of a  `@pytest.mark.nondestructive` decorator. I believe we should revert for now to get tests passing again and address re-adding working versions of the tests in a new PR.