### PR TITLE
Improve landing page redirects with multiple user agents and locales

### DIFF
--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -12,6 +12,7 @@ import requests
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('origin, destination, locale', [
     ('{base_url}/', '{base_url}/{locale}/', 'en-US'),
+    ('{base_url}/firefox/', '{base_url}/{locale}/firefox/new/', 'en-US'),
     ('{base_url}/fennec/', '{base_url}/{locale}/firefox/partners/', 'en-US'),
     ('{base_url}/firefox/mobile/', '{base_url}/{locale}/firefox/android/', 'en-US'),
     ('{base_url}/aurora/', '{base_url}/{locale}/firefox/channel/', 'en-US'),

--- a/tests/test_redirect_landing.py
+++ b/tests/test_redirect_landing.py
@@ -5,113 +5,71 @@
 import pytest
 import requests
 
-nondestructive = pytest.mark.nondestructive
-redirect = pytest.mark.redirect
-skip_selenium = pytest.mark.skip_selenium
+# List of the current supported locales on /firefox/new/
+LOCALES = (
+    'ar', 'ast', 'bg', 'bn-IN', 'ca', 'cs', 'de', 'dsb', 'el', 'en-GB',
+    'en-US', 'es-CL', 'es-ES', 'fr', 'fy-NL', 'gd', 'it', 'ja', 'ko', 'nl',
+    'pt-BR', 'pt-PT', 'ru', 'sv-SE', 'tr', 'uk', 'zh-TW')
+
+# List of some locale name variants including unsupported short names and
+# obsolete ab-CD-style names, which could be included in the visitors'
+# Accept-Language HTTP header and should be redirected to the respective
+# canonical locales
+LOCALE_VARIANTS = {
+    'en': 'en-US',
+    'en-CA': 'en-US',
+    'es': 'es-ES',
+    'es-419': 'es-ES',
+    'fr-FR': 'fr',
+    'ja-JP-mac': 'ja',
+    'pt': 'pt-BR',
+    'ta-LK': 'ta'}
+
+USER_AGENTS = {
+    'FIREFOX': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:24.0) Gecko/20100101 Firefox/24.0',
+    'ESR_FIREFOX': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:17.0) Gecko/17.0 Firefox/17.0.8',
+    'OLD_FIREFOX': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:16.0) Gecko/16.0 Firefox/16.0',
+    'MOBILE': 'Mozilla/5.0 (Linux; U; Android 4.0.3; HTC Sensation Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    'NON_FIREFOX': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.4 Safari/537.1',
+    'IOS': 'Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9A405'}
 
 
-@redirect
-@skip_selenium
-class TestRedirectLanding(object):
-    # List of the current supported locales on /firefox/new/
-    LOCALES = (
-        'ar', 'ast', 'bg', 'bn-IN', 'ca', 'cs', 'de', 'dsb', 'el', 'en-GB',
-        'es-CL', 'es-ES', 'fr', 'fy-NL', 'gd', 'it', 'ja', 'ko', 'nl',
-        'pt-BR', 'pt-PT', 'ru', 'sv-SE', 'tr', 'uk', 'zh-TW'
-    )
-    # List of some locale name variants including unsupported short names and
-    # obsolete ab-CD-style names, which could be included in the visitors'
-    # Accept-Language HTTP header and should be redirected to the respective
-    # canonical locales
-    LOCALE_VARIANTS = {
-        'en': 'en-US',
-        'en-CA': 'en-US',
-        'es': 'es-ES',
-        'es-419': 'es-ES',
-        'fr-FR': 'fr',
-        'ja-JP-mac': 'ja',
-        'pt': 'pt-BR',
-        'ta-LK': 'ta',
-    }
-    ACCEPT_LANGUAGE = {'Accept-Language': 'en-US'}
-    FIREFOX = {'User-Agent': ' Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:24.0) Gecko/20100101 Firefox/24.0'}
-    ESR_FIREFOX = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:17.0) Gecko/17.0 Firefox/17.0.8'}
-    OLD_FIREFOX = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:16.0) Gecko/16.0 Firefox/16.0'}
-    MOBILE = {'User-Agent': 'Mozilla/5.0 (Linux; U; Android 4.0.3; HTC Sensation Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'}
-    NON_FIREFOX = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.4 Safari/537.1'}
-    IOS = {'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9A405'}
+def pytest_generate_tests(metafunc):
+    argvalues = []
+    for user_agent in USER_AGENTS.values():
+        # check the landing page redirects for each user agent
+        argvalues.append((
+            '{base_url}/firefox/',
+            '{base_url}/{locale}/firefox/new/',
+            'en-US', user_agent))
+    for locale in LOCALES:
+        # check the landing page redirects for each locale
+        for user_agent in [USER_AGENTS['FIREFOX'],
+                           USER_AGENTS['ESR_FIREFOX'],
+                           USER_AGENTS['MOBILE']]:
+            argvalues.append((
+                '{base_url}/firefox/',
+                '{base_url}/{locale}/firefox/new/',
+                locale, user_agent))
+    for variant, locale in LOCALE_VARIANTS.items():
+        # check the landing page redirects for each locale variant
+        argvalues.append((
+            '{base_url}/firefox/',
+            '{base_url}/%s/firefox/new/' % locale,
+            variant, USER_AGENTS['FIREFOX']))
+    metafunc.parametrize('origin, destination, locale, user_agent', argvalues)
 
-    def _test_redirect(self, mozwebqa, origin, final, headers):
-        url = mozwebqa.base_url + origin
-        response = requests.get(url, headers=headers)
-        assert final in response.url
 
-    @nondestructive
-    def test_redirect_firefox(self, mozwebqa):
-        headers = {}
-        headers.update(self.ACCEPT_LANGUAGE)
-        headers.update(self.FIREFOX)
-        self._test_redirect(mozwebqa, '/firefox/', 'en-US/firefox/new/', headers)
-
-    @nondestructive
-    def test_redirect_ios_using_en_US(self, mozwebqa):
-        headers = {}
-        headers.update(self.IOS)
-        headers.update(self.ACCEPT_LANGUAGE)
-        self._test_redirect(mozwebqa, '/firefox/', '/en-US/firefox/new/', headers)
-
-    @nondestructive
-    def test_redirect_esr_firefox_using_en_US(self, mozwebqa):
-        headers = {}
-        headers.update(self.ESR_FIREFOX)
-        headers.update(self.ACCEPT_LANGUAGE)
-        self._test_redirect(mozwebqa, '/firefox/', '/firefox/new/', headers)
-
-    @nondestructive
-    def test_redirect_non_firefox(self, mozwebqa):
-        headers = {}
-        headers.update(self.NON_FIREFOX)
-        headers.update(self.ACCEPT_LANGUAGE)
-        self._test_redirect(mozwebqa, '/firefox/', '/en-US/firefox/new/', headers)
-
-    @nondestructive
-    def test_redirect_mobile_using_en_US(self, mozwebqa):
-        headers = {}
-        headers.update(self.ACCEPT_LANGUAGE)
-        headers.update(self.MOBILE)
-        self._test_redirect(mozwebqa, '/firefox/', '/firefox/new/', headers)
-
-    @nondestructive
-    def test_redirect_firefox_using_locale(self, mozwebqa):
-        headers = {}
-        headers.update(self.FIREFOX)
-        for locale in self.LOCALES:
-            headers.update({'Accept-Language': locale})
-            final = '/%s/firefox/new/' % locale
-            self._test_redirect(mozwebqa, '/firefox/', final, headers)
-
-    @nondestructive
-    def test_redirect_firefox_using_locale_variant(self, mozwebqa):
-        headers = {}
-        headers.update(self.FIREFOX)
-        for variant, locale in self.LOCALE_VARIANTS.items():
-            headers.update({'Accept-Language': variant})
-            final = '/%s/firefox/new/' % locale
-            self._test_redirect(mozwebqa, '/firefox/', final, headers)
-
-    @nondestructive
-    def test_redirect_mobile_using_locale(self, mozwebqa):
-        headers = {}
-        headers.update(self.MOBILE)
-        for locale in self.LOCALES:
-            headers.update({'Accept-Language': locale})
-            self._test_redirect(mozwebqa, '/firefox/', '/firefox/new/', headers)
-
-    @nondestructive
-    def test_redirect_esr_firefox_using_locale(self, mozwebqa):
-        headers = {}
-        headers.update(self.ESR_FIREFOX)
-        for locale in self.LOCALES:
-            headers.update({'Accept-Language': locale})
-            final = '/%s/firefox/new/' % locale
-            self._test_redirect(mozwebqa, '/firefox/', final, headers)
+@pytest.mark.skip_selenium
+@pytest.mark.nondestructive
+def test_redirect(origin, destination, locale, user_agent, mozwebqa):
+    url = origin.format(base_url=mozwebqa.base_url, locale=locale)
+    headers = {'Accept-Language': locale}
+    if user_agent is not None:
+        headers['User-Agent'] = user_agent
+    r = requests.get(url, allow_redirects=True, headers=headers)
+    for h in r.history:
+        assert h.status_code in [requests.codes.moved_permanently,
+                                 requests.codes.found]
+    assert destination.format(base_url=mozwebqa.base_url, locale=locale) == r.url
+    assert requests.codes.ok == r.status_code, r.url


### PR DESCRIPTION
Parameterize the landing page redirects with multiple user agents and locales. I've avoided changing the assertions and test data, although the user agents appear to be very out of date. I would have liked to try to combine this with the tests in `test_redirects.py` but I didn't want to spend too much time on it. Ultimately we're likely to try to merge these redirect tests with those in the bedrock repository.

Pinging @bobsilverberg and @alexgibson for review.