### PR TITLE
Remove sign up tests in favour of new tests in bedrock

### DIFF
--- a/pages/desktop/about.py
+++ b/pages/desktop/about.py
@@ -47,9 +47,6 @@ class AboutPage(Base):
         }
     ]
 
-    _sign_up_form_locator = (By.ID, 'mozorg-newsletter-form')
-    _sign_up_form_email_input_locator = (By.ID, 'id_email')
-    _sign_up_form_country_select_locator = (By.ID, 'country')
     _sign_up_form_privacy_checkbox_locator = (By.ID, 'id_privacy')
     _sign_up_form_submit_button_locator = (By.ID, 'footer_email_submit')
 
@@ -60,33 +57,8 @@ class AboutPage(Base):
         },
     ]
 
-    sign_up_form_fields = [
-        {
-            'locator': (By.ID, 'id_email'),
-        }, {
-            'locator': (By.ID, 'country'),
-        }, {
-            'locator': (By.ID, 'id_privacy'),
-        }, {
-            'locator': (By.ID, 'footer_email_submit'),
-        },
-    ]
-
-    def input_email(self, email):
-        self.selenium.find_element(*self._sign_up_form_email_input_locator).send_keys(email)
-
-    def check_privacy_checkbox(self):
-        self.selenium.find_element(*self._sign_up_form_privacy_checkbox_locator).click()
-
-    def submit_form(self):
-        self.selenium.find_element(*self._sign_up_form_submit_button_locator).click()
-
     def expand_sign_up_form(self):
         self.selenium.find_element(*self._sign_up_form_submit_button_locator).click()
         Wait(self.selenium, self.timeout).until(
             expected.visibility_of_element_located(
                 self._sign_up_form_privacy_checkbox_locator))
-
-    @property
-    def is_sign_up_form_present(self):
-        return self.is_element_present(*self._sign_up_form_locator)

--- a/pages/desktop/home.py
+++ b/pages/desktop/home.py
@@ -81,8 +81,6 @@ class HomePage(Base):
         },
     ]
 
-    _sign_up_form_locator = (By.ID, 'mozorg-newsletter-form')
-
     sign_up_form_link_list = [
         {
             'locator': (By.CSS_SELECTOR, 'label.privacy-check-label > span > a'),
@@ -101,7 +99,3 @@ class HomePage(Base):
                 'locator': (By.CSS_SELECTOR, '#upcoming-events .more-large'),
                 'url_suffix': '/contribute/events/',
             })
-
-    @property
-    def is_sign_up_form_present(self):
-        return self.is_element_present(*self._sign_up_form_locator)

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -86,83 +86,12 @@ class TestAboutPage:
         assert [] == bad_urls
 
     @pytest.mark.nondestructive
-    def test_sign_up_form_is_visible(self, base_url, selenium):
-        page = AboutPage(base_url, selenium).open()
-        assert page.is_sign_up_form_present, 'The sign up form is not present on the page.'
-
-    @pytest.mark.nondestructive
-    def test_sign_up_form_fields_are_visible(self, base_url, selenium):
-        page = AboutPage(base_url, selenium).open()
-        page.expand_sign_up_form()
-        bad_fields = []
-        for field in page.sign_up_form_fields:
-            if not page.is_element_visible(*field.get('locator')):
-                bad_fields.append('The field at %s is not visible' % field.get('locator')[1:])
-        assert [] == bad_fields
-
-    @pytest.mark.nondestructive
-    def test_sign_up_form_links_are_visible(self, base_url, selenium):
+    def test_sign_up_form_links(self, base_url, selenium):
         page = AboutPage(base_url, selenium).open()
         page.expand_sign_up_form()
         page.wait_for_element_visible(*page._sign_up_form_privacy_checkbox_locator)
-        bad_links = []
         for link in page.sign_up_form_link_list:
-            if not page.is_element_visible(*link.get('locator')):
-                bad_links.append('The link at %s is not visible' % link.get('locator')[1:])
-        assert [] == bad_links
-
-    @pytest.mark.nondestructive
-    def test_sign_up_form_link_destinations_are_correct(self, base_url, selenium):
-        page = AboutPage(base_url, selenium).open()
-        bad_links = []
-        for link in page.sign_up_form_link_list:
+            assert page.is_element_visible(*link.get('locator'))
             url = page.link_destination(link.get('locator'))
-            if not url.endswith(link.get('url_suffix')):
-                bad_links.append('%s does not end with %s' % (url, link.get('url_suffix')))
-        assert [] == bad_links
-
-    @pytest.mark.link_check
-    @pytest.mark.nondestructive
-    def test_sign_up_form_link_urls_are_valid(self, base_url, selenium):
-        page = AboutPage(base_url, selenium).open()
-        bad_urls = []
-        for link in page.sign_up_form_link_list:
-            url = page.link_destination(link.get('locator'))
-            response_code = page.get_response_code(url)
-            if response_code != requests.codes.ok:
-                bad_urls.append('%s is not a valid url - status code: %s.' % (url, response_code))
-        assert [] == bad_urls
-
-    @pytest.mark.nondestructive
-    def test_sign_up_form_elements_are_visible(self, base_url, selenium):
-        page = AboutPage(base_url, selenium).open()
-        page.expand_sign_up_form()
-        page.wait_for_element_visible(*page._sign_up_form_privacy_checkbox_locator)
-        assert page.is_element_visible(*page._sign_up_form_country_select_locator)
-
-    @pytest.mark.nondestructive
-    def test_sign_up_form_invalid_email(self, base_url, selenium):
-        page = AboutPage(base_url, selenium).open()
-        invalid_email = 'noreplymozilla.com'
-        country = 'US'
-        expected_url = page.url_current_page
-        page.expand_sign_up_form()
-        page.wait_for_element_visible(*page._sign_up_form_privacy_checkbox_locator)
-        page.input_email(invalid_email)
-        page.select_option(country, page._sign_up_form_country_select_locator)
-        page.check_privacy_checkbox()
-        page.submit_form()
-        assert expected_url == page.url_current_page[:len(expected_url)]
-
-    @pytest.mark.nondestructive
-    def test_sign_up_form_privacy_policy_unchecked(self, base_url, selenium):
-        page = AboutPage(base_url, selenium).open()
-        valid_email = 'noreply@mozilla.com'
-        country = 'US'
-        expected_url = page.url_current_page
-        page.expand_sign_up_form()
-        page.wait_for_element_visible(*page._sign_up_form_privacy_checkbox_locator)
-        page.input_email(valid_email)
-        page.select_option(country, page._sign_up_form_country_select_locator)
-        page.submit_form()
-        assert expected_url == page.url_current_page[:len(expected_url)]
+            assert url.endswith(link.get('url_suffix'))
+            assert requests.codes.ok == page.get_response_code(url)

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -67,28 +67,9 @@ class TestHomePage:
         assert [] == bad_urls
 
     @pytest.mark.nondestructive
-    def test_sign_up_form_is_visible(self, base_url, selenium):
+    def test_sign_up_form_links(self, base_url, selenium):
         page = HomePage(base_url, selenium).open()
-        assert page.is_sign_up_form_present, 'The sign up form is not present on the page.'
-
-    @pytest.mark.nondestructive
-    def test_sign_up_form_link_destinations_are_correct(self, base_url, selenium):
-        page = HomePage(base_url, selenium).open()
-        bad_links = []
         for link in page.sign_up_form_link_list:
             url = page.link_destination(link.get('locator'))
-            if not url.endswith(link.get('url_suffix')):
-                bad_links.append('%s does not end with %s' % (url, link.get('url_suffix')))
-        assert [] == bad_links
-
-    @pytest.mark.link_check
-    @pytest.mark.nondestructive
-    def test_sign_up_form_link_urls_are_valid(self, base_url, selenium):
-        page = HomePage(base_url, selenium).open()
-        bad_urls = []
-        for link in page.sign_up_form_link_list:
-            url = page.link_destination(link.get('locator'))
-            response_code = page.get_response_code(url)
-            if response_code != requests.codes.ok:
-                bad_urls.append('%s is not a valid url - status code: %s.' % (url, response_code))
-        assert [] == bad_urls
+            assert url.endswith(link.get('url_suffix'))
+            assert requests.codes.ok == page.get_response_code(url)


### PR DESCRIPTION
We have coverage of the sign up form in [these new bedrock tests](https://github.com/mozilla/bedrock/blob/d543a1783ba820828fd33e58f1771d354d1886da/tests/functional/test_home.py#L51-L77) so I'd like to remove the mostly duplicate checks from here.

The main difference is that we're checking the sign up form from the __home__ page in bedrock, whereas we were testing it from the __about__ page here. Other than that, we don't have a check for the privacy link in bedrock. This will ultimately be covered by a link checker, but if we feel we need a check for this in the meantime I can either leave a basic test here, or add one to bedrock that clicks the link and makes sure we get the expected page.

@alexgibson do you feel that our coverage in bedrock is good enough for us to remove these? Do we need to check the form from the __about__ page? Do we need to maintain coverage for the privacy link?