### PR TITLE
Remove functional tests for contact pages in favour of the new suite

### DIFF
--- a/pages/desktop/contact.py
+++ b/pages/desktop/contact.py
@@ -7,47 +7,9 @@ from selenium.webdriver.common.by import By
 from pages.desktop.base import Base
 
 
-class Contact(Base):
-
-    _url = '{base_url}/{locale}/contact'
-
-    _spaces_tab_locator = (By.CSS_SELECTOR, '.category-tabs > li[data-id=spaces]')
-    _contact_tab_locator = (By.CSS_SELECTOR, '.category-tabs > li[data-id=contact]')
-    _communities_tab_locator = (By.CSS_SELECTOR, '.category-tabs > li[data-id=communities]')
-    _spaces_tab_link_locator = (By.CSS_SELECTOR,
-                                '#page-content > .category-tabs > li[data-id=spaces] > a')
-    _communities_tab_link_locator = (By.CSS_SELECTOR,
-                                     '#page-content > .category-tabs > li[data-id=communities] > a')
-
-    @property
-    def contact_tab(self):
-        return self.selenium.find_element(*self._contact_tab_locator)
-
-    @property
-    def spaces_tab(self):
-        return self.selenium.find_element(*self._spaces_tab_locator)
-
-    @property
-    def communities_tab(self):
-        return self.selenium.find_element(*self._communities_tab_locator)
-
-    def click_spaces_tab(self):
-        spaces_tab_link = self.selenium.find_element(*self._spaces_tab_link_locator)
-        spaces_tab_link.click()
-        return Spaces(self.base_url, self.selenium).wait_for_page_to_load()
-
-    def click_communities_tab(self):
-        communities_tab_link = self.selenium.find_element(*self._communities_tab_link_locator)
-        communities_tab_link.click()
-        return Communities(self.base_url, self.selenium).wait_for_page_to_load()
-
-
-class Spaces(Contact):
+class Spaces(Base):
 
     _url = '{base_url}/{locale}/contact/spaces'
-
-    _spaces_list_locator = (By.ID, 'nav-spaces')
-    _spaces_marker_locator = (By.CSS_SELECTOR, '#map .leaflet-marker-pane > .leaflet-marker-icon')
 
     spaces_nav_links_list = [
         {
@@ -89,90 +51,10 @@ class Spaces(Contact):
         }
     ]
 
-    @property
-    def spaces_markers(self):
-        return self.selenium.find_elements(*self._spaces_marker_locator)
 
-    @property
-    def spaces_links(self):
-        return [self.selenium.find_element(*link.get('locator'))
-                for link in self.spaces_nav_links_list]
-
-    @property
-    def spaces_list(self):
-        return self.selenium.find_element(*self._spaces_list_locator)
-
-
-class Communities(Contact):
+class Communities(Base):
 
     _url = '{base_url}/{locale}/contact/communities'
-
-    _region_list_locator = (By.ID, 'nav-communities')
-    _region_legend_locator = (By.CSS_SELECTOR, '#map > ul')
-    _communities_link_locator = (By.CSS_SELECTOR,
-                                 '#nav-communities > ul > .hasmenu > .submenu > li > a')
-
-    def click_north_america(self):
-        self.selenium.find_element(By.CSS_SELECTOR,
-                                   '#nav-communities > ul > li[data-id=north-america] > a').click()
-
-    def click_latin_america(self):
-        self.selenium.find_element(By.CSS_SELECTOR,
-                                   '#nav-communities > ul > li[data-id=latin-america] > a').click()
-
-    def click_europe(self):
-        self.selenium.find_element(By.CSS_SELECTOR,
-                                   '#nav-communities > ul > li[data-id=europe] > a').click()
-
-    def click_asia_south_pacific(self):
-        self.selenium.find_element(By.CSS_SELECTOR,
-                                   '#nav-communities > ul > li[data-id=asia] > a').click()
-
-    def click_africa_middle_east(self):
-        self.selenium.find_element(By.CSS_SELECTOR,
-                                   '#nav-communities > ul > li[data-id=africa] > a').click()
-
-    def click_balkans(self):
-        self.selenium.find_element(By.CSS_SELECTOR,
-                                   '#nav-communities > ul > li[data-id=balkans] > a').click()
-
-    @property
-    def north_america_communities(self):
-        return self.selenium.find_elements(By.CSS_SELECTOR,
-                                           '#nav-communities > ul > li[data-id=north-america] > .submenu > li')
-
-    @property
-    def latin_america_communities(self):
-        return self.selenium.find_elements(By.CSS_SELECTOR,
-                                           '#nav-communities > ul > li[data-id=latin-america] > .submenu > li')
-
-    @property
-    def europe_communities(self):
-        return self.selenium.find_elements(By.CSS_SELECTOR,
-                                           '#nav-communities > ul > li[data-id=europe] > .submenu > li')
-
-    @property
-    def asia_south_pacific_communities(self):
-        return self.selenium.find_elements(By.CSS_SELECTOR,
-                                           '#nav-communities > ul > li[data-id=asia] > .submenu > li')
-
-    @property
-    def africa_middle_east_communities(self):
-        return self.selenium.find_elements(By.CSS_SELECTOR,
-                                           '#nav-communities > ul > li[data-id=africa] > .submenu > li')
-
-    @property
-    def balkans_communities(self):
-        return self.selenium.find_elements(By.CSS_SELECTOR,
-                                           '#nav-communities > ul > li[data-id=balkans] > .submenu > li')
-
-    @property
-    def region_list(self):
-        return self.selenium.find_element(*self._region_list_locator)
-
-    @property
-    def region_legend(self):
-        return self.selenium.find_element(*self._region_legend_locator)
 
     region_nav_links_list = [
         {

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from pages.desktop.contact import Contact, Spaces, Communities
+from pages.desktop.contact import Spaces, Communities
 
 
 class TestContact:
@@ -23,33 +23,6 @@ class TestContact:
         self.check_bad_links(page, page.spaces_nav_links_list)
 
     @pytest.mark.nondestructive
-    def test_start_on_contact(self, base_url, selenium):
-        page = Contact(base_url, selenium).open()
-        assert 'current' == page.contact_tab.get_attribute('class'), 'Page does not start on spaces tab.'
-
-    @pytest.mark.nondestructive
-    def test_switching_tabs_list_display(self, base_url, selenium):
-        spaces_page = Spaces(base_url, selenium).open()
-        communities_page = spaces_page.click_communities_tab()
-        communities_page.wait_for_element_visible(communities_page.region_list)
-        assert communities_page.region_list.is_displayed(), 'List of regions not displayed on communities tab.'
-        spaces_page = communities_page.click_spaces_tab()
-        spaces_page.wait_for_element_visible(spaces_page.spaces_list)
-        assert spaces_page.spaces_list.is_displayed(), 'List of spaces not displayed on spaces tab.'
-
-    @pytest.mark.nondestructive
-    def test_spaces_map_marker_visibility(self, base_url, selenium):
-        page = Spaces(base_url, selenium).open()
-        print len(page.spaces_markers)
-        bad_markers = []
-        for index, space in enumerate(page.spaces_links):
-            space.click()
-            page.wait_for_element_visible(page.spaces_markers[index])
-            if not page.spaces_markers[index].is_displayed():
-                bad_markers.append('%s marker is not visible.' % space.text)
-        assert [] == bad_markers
-
-    @pytest.mark.nondestructive
     def test_region_links_are_correct(self, base_url, selenium):
         page = Communities(base_url, selenium).open()
         self.check_bad_links(page, page.region_nav_links_list)
@@ -57,30 +30,4 @@ class TestContact:
     @pytest.mark.nondestructive
     def test_region_legend_links_are_correct(self, base_url, selenium):
         page = Communities(base_url, selenium).open()
-        assert page.region_legend.is_displayed(), 'Legend not displayed'
         self.check_bad_links(page, page.region_legend_links_list)
-
-    @pytest.mark.nondestructive
-    def test_region_dropdown_link(self, base_url, selenium):
-        page = Communities(base_url, selenium).open()
-        click_regions = [
-            page.click_north_america,
-            page.click_latin_america,
-            page.click_europe,
-            page.click_asia_south_pacific,
-            page.click_africa_middle_east]
-        region_communities = [
-            page.north_america_communities,
-            page.latin_america_communities,
-            page.europe_communities,
-            page.asia_south_pacific_communities,
-            page.africa_middle_east_communities,
-            page.balkans_communities]
-        bad_communities = []
-        for index, action in enumerate(click_regions):
-            action()
-            for community in region_communities[index]:
-                page.wait_for_element_visible(community)
-                if not community.is_displayed():
-                    bad_communities.append('%s is not displayed.' % community.text)
-        assert [] == bad_communities


### PR DESCRIPTION
The new tests landed here: https://github.com/mozilla/bedrock/commit/1abe0e00752095a9c3be13e490dfdef4244a4270. I'm leaving the link checking tests until we've set up a regular job to check links across the entire site.

@alexgibson r?