### PR TITLE
Remove tests for do not track page in favour of new suite

### DIFF
--- a/pages/desktop/dnt.py
+++ b/pages/desktop/dnt.py
@@ -11,11 +11,6 @@ class DoNotTrack(Base):
 
     _url = '{base_url}/{locale}/firefox/dnt'
 
-    _dnt_status_wrapper_locator = (By.ID, 'dnt-status-wrapper')
-    _dnt_status_text_locator = (By.CSS_SELECTOR, '#dnt-status > h4')
-    _enable_dnt_text_locator = (By.CSS_SELECTOR, '.sidebar-inset > h4')
-    _enable_dnt_image_locator = (By.CSS_SELECTOR, '.sidebar-inset > p > a > img')
-    _enable_dnt_link_locator = (By.CSS_SELECTOR, '.sidebar-inset > p > a')
     tracking_protection_links_list = [
         {
             'locator': (By.CSS_SELECTOR, '.sidebar-box > p > a:nth-of-type(1)'),
@@ -26,22 +21,3 @@ class DoNotTrack(Base):
             'url_suffix': 'dnt-enabler.*.tpl'
         }
     ]
-
-    @property
-    def is_status_wrapper_visible(self):
-        return self.is_element_visible(*self._dnt_status_wrapper_locator)
-
-    @property
-    def is_status_text_visible(self):
-        return self.is_element_visible(*self._dnt_status_text_locator)
-
-    @property
-    def is_enable_dnt_text_visible(self):
-        return self.is_element_visible(*self._enable_dnt_text_locator)
-
-    @property
-    def is_enable_dnt_image_visible(self):
-        return self.is_element_visible(*self._enable_dnt_image_locator)
-
-    def are_tracking_protection_links_visible(self, locator):
-        return self.is_element_visible(*locator)

--- a/tests/test_dnt.py
+++ b/tests/test_dnt.py
@@ -24,10 +24,6 @@ class TestDoNotTrack:
     @pytest.mark.nondestructive
     def test_status_section(self, base_url, selenium):
         page = DoNotTrack(base_url, selenium).open()
-        assert page.is_status_wrapper_visible
-        assert page.is_status_text_visible
-        assert page.is_enable_dnt_image_visible
-        assert page.is_enable_dnt_text_visible
         bad_links = []
         for link in page.tracking_protection_links_list:
             url = page.link_destination(link.get('locator'))


### PR DESCRIPTION
New tests can be found here: https://github.com/mozilla/bedrock/blob/master/tests/functional/firefox/test_do_not_track.py.

These tests also checked the visibility of several additional elements, but I don't feel these check add much value. I'm leaving the link checking tests until we have a link checker running regularly.

@alexgibson r?