### PR TITLE
Remove tests for nightly first run in favour of new suite

### DIFF
--- a/pages/desktop/mission.py
+++ b/pages/desktop/mission.py
@@ -31,11 +31,6 @@ class Mission(Base):
     ]
 
     _video_sources_locator = (By.CSS_SELECTOR, 'video source')
-    _video_overlay_locator = (By.CSS_SELECTOR, '.mozilla-video-control-overlay')
-
-    @property
-    def is_video_overlay_visible(self):
-        return self.is_element_visible(*self._video_overlay_locator)
 
     @property
     def video_sources_list(self):

--- a/pages/desktop/nightlyfirstrun.py
+++ b/pages/desktop/nightlyfirstrun.py
@@ -2,48 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from selenium.webdriver.common.by import By
-
 from pages.desktop.base import Base
 
 
 class NightlyFirstRun(Base):
 
     _url = '{base_url}/{locale}/firefox/nightly/firstrun'
-
-    _test_section_locator = (By.CSS_SELECTOR, '.blue-box.test')
-    _test_button_locator = (By.CSS_SELECTOR, '.test > .content > a')
-    _code_section_locator = (By.CSS_SELECTOR, '.blue-box.code')
-    _code_button_locator = (By.CSS_SELECTOR, '.code > .content > a')
-    _localize_section_locator = (By.CSS_SELECTOR, '.blue-box.localize')
-    _localize_button_locator = (By.CSS_SELECTOR, '.localize > .content > a')
-    _nightly_badge_img_locator = (By.CSS_SELECTOR, '.blue-box.badge')
-    _nightly_badge_link_locator = (By.CSS_SELECTOR, '.blue-box.badge > a')
-
-    @property
-    def is_test_section_visible(self):
-        return self.is_element_visible(*self._test_section_locator)
-
-    @property
-    def is_code_section_visible(self):
-        return self.is_element_visible(*self._code_section_locator)
-
-    @property
-    def is_localize_section_visible(self):
-        return self.is_element_visible(*self._localize_button_locator)
-
-    @property
-    def is_nightly_badge_visible(self):
-        return self.is_element_visible(*self._nightly_badge_img_locator)
-
-    @property
-    def is_localize_button_visible(self):
-        return self.is_element_visible(*self._localize_button_locator)
-
-    @property
-    def is_code_button_visible(self):
-        return self.is_element_visible(*self._code_button_locator)
-
-    @property
-    def is_test_button_visible(self):
-        return self.is_element_visible(*self._test_button_locator)

--- a/tests/test_nightlyfirstrun.py
+++ b/tests/test_nightlyfirstrun.py
@@ -31,14 +31,3 @@ class TestNightlyFirstRun:
             if response_code != requests.codes.ok:
                 bad_urls.append('%s is not a valid url - status code: %s.' % (url, response_code))
         assert [] == bad_urls
-
-    @pytest.mark.nondestructive
-    def test_are_sections_visible(self, base_url, selenium):
-        page = NightlyFirstRun(base_url, selenium).open()
-        assert page.is_test_section_visible
-        assert page.is_code_section_visible
-        assert page.is_localize_section_visible
-        assert page.is_nightly_badge_visible
-        assert page.is_code_button_visible
-        assert page.is_test_button_visible
-        assert page.is_localize_button_visible


### PR DESCRIPTION
New tests can be found here: https://github.com/mozilla/bedrock/pull/3634. I'm leaving the link checking tests until we have a link checker running regularly.

@alexgibson r?