### PR TITLE
Remove Persona redirect test

### DIFF
--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -38,7 +38,6 @@ import requests
     ('{base_url}/newsletter/', '{base_url}/{locale}/newsletter/', 'en-US'),
     ('{base_url}/newsletter/', '{base_url}/{locale}/newsletter/', 'pl'),
     ('{base_url}/firefox/mobile/faq/?os=firefox-os', '{base_url}/{locale}/firefox/os/faq/', 'en-US'),
-    ('{base_url}/firefox/accountmanager/', '{base_url}/{locale}/persona/', 'en-US'),
     ('{base_url}/apps/', 'https://marketplace.firefox.com/', 'en-US'),
     ('{base_url}/firefox/technology/', 'https://developer.mozilla.org/{locale}/docs/Tools', 'en-US'),
     ('{base_url}/firefox/performance/', '{base_url}/{locale}/firefox/desktop/fast/', 'en-US'),


### PR DESCRIPTION
We're decommissioning the Persona pages in https://github.com/mozilla/bedrock/pull/3771

This removes a redundant redirect test that we [already have in bedrock](https://github.com/mozilla/bedrock/blob/master/test_redirects/map_globalconf.py#L787)