### PR TITLE
Remove redundant Firefox OS FAQ redirect test

### DIFF
--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -37,7 +37,6 @@ import requests
     ('{base_url}/metrofirefox/', '{base_url}/{locale}/firefox/new/', 'en-US'),
     ('{base_url}/newsletter/', '{base_url}/{locale}/newsletter/', 'en-US'),
     ('{base_url}/newsletter/', '{base_url}/{locale}/newsletter/', 'pl'),
-    ('{base_url}/firefox/mobile/faq/?os=firefox-os', '{base_url}/{locale}/firefox/os/faq/', 'en-US'),
     ('{base_url}/apps/', 'https://marketplace.firefox.com/', 'en-US'),
     ('{base_url}/firefox/technology/', 'https://developer.mozilla.org/{locale}/docs/Tools', 'en-US'),
     ('{base_url}/firefox/performance/', '{base_url}/{locale}/firefox/desktop/fast/', 'en-US'),


### PR DESCRIPTION
This was updated in the equivalent bedrock test: https://github.com/mozilla/bedrock/pull/3864

But is currently causing the pipeline builds to fail: https://ci.us-west.moz.works/job/bedrock_test_dev_eu_west/1128/